### PR TITLE
Fix Console2 download failing due to redirect responses

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,12 +29,6 @@ task :build do
 	assemble_kitchen
 end
 
-task :download do
-	recreate_dirs
-	download_tools
-end
-
-
 def recreate_dirs
 	FileUtils.rm_rf BUILD_DIR
 	%w{ boxes docs home install repo tools }.each do |dir|


### PR DESCRIPTION
Fixes failure to download Console2 due to Sourceforge redirect. Limits redirect responses to 5 to prevent infinite recursion in case of  redirect loop.
