### PR TITLE
issue with invalid run_list because of misplaced '

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,4 +1,3 @@
-
 # Getting Started
 
 Getting started with Chef and Vagrant.
@@ -238,7 +237,7 @@ VM, run `vagrant status NAME`.
 Ok, looks good. Now lets go ahead and bootstrap that VM using chef. That process might take a while - it will ssh into that VM and install the chef-client, then register the client at the server and finally converge the node to the desired state (i.e. "apply" webserver role as passed to the node's initial run_list). We bootstrap the new node with `role[webserver]` and `recipe[vagrant-ohai]` (the latter one fixes ohai's IP address detection when running inside Vagrant) and use the "[chef-full](https://github.com/opscode/chef/blob/10.16.2/chef/lib/chef/knife/bootstrap/chef-full.erb)" a.k.a "omnibus" bootstrap template:
 
 ```
-W:\repo\my-chef-repo>knife bootstrap 33.33.3.11 -x vagrant -P vagrant --sudo -N my-node -r 'role[webserver],recipe[vagrant-ohai] -d chef-full'
+W:\repo\my-chef-repo>knife bootstrap 33.33.3.11 -x vagrant -P vagrant --sudo -N my-node -r 'role[webserver],recipe[vagrant-ohai]' -d chef-full
 Bootstrapping Chef on 33.33.3.11
 ...
 33.33.3.11 Successfully installed chef-10.16.2


### PR DESCRIPTION
The bootstrap should look like
-r 'role[webserver],recipe[vagrant-ohai]' -d chef-full
but is showing as
-r 'role[webserver],recipe[vagrant-ohai] -d chef-full'

which will give you an error of  because it is trying to load cookbook -d and chef-full

33.33.3.11 Expanded Run List:
33.33.3.11
33.33.3.11 ------------------
33.33.3.11
33.33.3.11 \* apache2
33.33.3.11
33.33.3.11 \* apache2::mod_ssl
33.33.3.11
33.33.3.11 \* vagrant-ohai
33.33.3.11
33.33.3.11 \* -d
33.33.3.11
33.33.3.11 \* chef-full
33.33.3.11 [2012-12-08T17:56:46+00:00] ERROR: Running exception handlers
33.33.3.11
33.33.3.11 [2012-12-08T17:56:46+00:00] FATAL: Saving node information to /var/chef/cache/failed-run-data.json
33.33.3.11
33.33.3.11 [2012-12-08T17:56:46+00:00] ERROR: Exception handlers complete
33.33.3.11
33.33.3.11 [2012-12-08T17:56:46+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
33.33.3.11
33.33.3.11 [2012-12-08T17:56:46+00:00] FATAL: Net::HTTPServerException: 412 "Precondition Failed"
