### PR TITLE
update RUBYDIR environment variable to ruby-1.9.3-p392-i386-mingw32

### DIFF
--- a/files/set-env.bat
+++ b/files/set-env.bat
@@ -7,7 +7,7 @@
 set SCRIPT_DIR=%~dp0
 
 :: for these we need the bin dirs in PATH
-set RUBYDIR=%SCRIPT_DIR%tools\ruby\ruby-1.9.3-p385-i386-mingw32
+set RUBYDIR=%SCRIPT_DIR%tools\ruby\ruby-1.9.3-p392-i386-mingw32
 set DEVKITDIR=%SCRIPT_DIR%tools\devkit
 set KDIFF3DIR=%SCRIPT_DIR%tools\kdiff3
 set CYGWINSSHDIR=%SCRIPT_DIR%tools\cygwin-ssh

--- a/files/set-env.ps1
+++ b/files/set-env.ps1
@@ -1,7 +1,7 @@
 
 $script:pwd = Split-Path $MyInvocation.MyCommand.Path
 
-$env:RUBYDIR = Join-Path $pwd tools\ruby\ruby-1.9.3-p385-i386-mingw32
+$env:RUBYDIR = Join-Path $pwd tools\ruby\ruby-1.9.3-p392-i386-mingw32
 $env:DEVKITDIR = Join-Path $pwd tools\devkit
 $env:KDIFF3DIR = Join-Path $pwd tools\kdiff3
 $env:CYGWINSSHDIR = Join-Path $pwd tools\cygwin-ssh


### PR DESCRIPTION
Whoops I forgot to update these in Pull Request https://github.com/tknerr/bills-kitchen/pull/33. 

I'm going to experiment with trying to unpack ruby straight into the ruby directory without the version named sub-directory so that we don't have to worry about updating them in three places going forward.
