### PR TITLE
remove custom `OMNIBUS_INSTALL_URL` now that the official install.sh sup...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  * set `ANSICON` env var so that Vagrant uses colored output on Windows
  * add up-to-date CA certs and set `SSL_CERT_FILE` ([#45](https://github.com/tknerr/bills-kitchen/issues/45))
  * add Vagrant's embedded dir to the `PATH` ([#46](https://github.com/tknerr/bills-kitchen/pull/46))
+ * remove custom `OMNIBUS_INSTALL_URL` now that the official one supports caching (see opscode/opscode-omnitruck#33)
  * tool updates ([#43](https://github.com/tknerr/bills-kitchen/pull/43)):
   * update to Ruby 1.9.3p545
   * update to Vagrant 1.3.5

--- a/files/home/.vagrant.d/Vagrantfile
+++ b/files/home/.vagrant.d/Vagrantfile
@@ -10,10 +10,3 @@ begin
 rescue LoadError
   # vagrant-vbguest not installed
 end
-
-# use a slightly modified omnibus install.sh downloads to `/tmp/vagrant-cache/chef` and thus works with cachier
-# see https://github.com/fgrehm/vagrant-cachier/issues/13
-if (defined? VagrantPlugins::Cachier && defined? VagrantPlugins::Omnibus)
-  ENV['OMNIBUS_INSTALL_URL']="https://gist.github.com/tknerr/6760407/raw/4879d46917b57e002b9dd6a3bdb096e8631db1a6/install.sh"
-  #puts "setting custom OMNIBUS_INSTALL_URL for vagrant-cachier: #{ENV['OMNIBUS_INSTALL_URL']}"
-end


### PR DESCRIPTION
This is a precautionary removal of the `OMNIBUS_INSTALL_URL` env var in `W:\home\.vagrant.d\Vagrantfile` now that the official install.sh supports caching (see opscode/opscode-omnitruck#33)

It is not effective yet until a new version of vagrant-omnibus is released which makes use of the `-d` flag. Track schisamo/vagrant-omnibus#68 for further progress on this.

The decision to remove the currently set `OMNIBUS_INSTALL_URL` env var eagerly is that we don't want to release this as 1.0. Until the above PR is ready, the existing caching of the omnibus packages will not work anymore. If you still need it you can always add it back manually. 
