### PR TITLE
first stab at restoring the ~/.chefdk dir for installing user gems, but ...

### DIFF
--- a/files/home/.bundle/config
+++ b/files/home/.bundle/config
@@ -1,3 +1,4 @@
 ---
+BUNDLE_PATH: ~/.chefdk/gem/ruby/2.0.0
 BUNDLE_JOBS: 16
 BUNDLE_RETRY: 3

--- a/files/home/.gemrc
+++ b/files/home/.gemrc
@@ -1,4 +1,0 @@
-# ensure that gems are NOT installed to ~/.chefdk/gem but rather 
-# to tools/chefdk/embedded/lib (does not work on windows otherwise)
-update: --no-user-install
-install: --no-user-install


### PR DESCRIPTION
...it still fails the acceptance tests

**Note: Keeping this PR open until the underlying issues are fixed.**

Essentially I want to restore the default behaviour of ChefDK where gems are installed into `~/.chefdk` rather than the chefdk embedded dir. This would be a clean separation between the chefdk shipped gems and the user / bundle installed gems again. It works on my ubuntu [dev-box](https://github.com/tknerr/dev-box/) without problems that way, but in bills kitchen it still fails the acceptance tests:
```
"--> Running command: 'cd C:/Repos/_github/bills-kitchen/target/build/repo/vagrant-workflow-tests/playground/sample-toplevel-cookbook && rake test':"
knife cookbook test sample-toplevel-cookbook -o ..
'"C:\Repos\_github\bills-kitchen\target\build\home\.chefdk\gem\ruby\2.0.0\bin\ruby.exe"' is not recognized as an internal or external command,
operable program or batch file.
rake aborted!
```

Might have to do or is related to the chefdk mangling we do here:
https://github.com/tknerr/bills-kitchen/blob/master/Rakefile#L117-132

Related ChefDK issues:
* https://github.com/opscode/chef-dk/issues/242
* https://github.com/opscode/chef/issues/1512