### PR TITLE
Chefdk update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 # 2.3 (unreleased)
 
- * ...
+ * update to ChefDK 0.3.6
 
 # 2.2 (January 18, 2015)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 
 # 2.3 (unreleased)
 
- * update to ChefDK 0.3.6
+ * tool updates:
+  * update to ChefDK 0.3.6
+ * improvements:
+  * mimic `chef shell-init` behaviour by setting env vars accordingly
+  * user installed gems will be installed to `$HOME/.chefdk` again (see [#71|https://github.com/tknerr/bills-kitchen/pull/71]) 
 
 # 2.2 (January 18, 2015)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A [DevPack](http://blog.tknerr.de/blog/2014/10/09/devpack-philosophy-aka-works-o
 
 The main tools for cooking with Chef / Vagrant:
 
-* [Chef-DK](http://www.getchef.com/downloads/chef-dk/windows/) 0.3.5, with embedded [Ruby](http://rubyinstaller.org/downloads/) 2.0.0
+* [Chef-DK](http://www.getchef.com/downloads/chef-dk/windows/) 0.3.6, with embedded [Ruby](http://rubyinstaller.org/downloads/) 2.0.0
 * [DevKit](http://rubyinstaller.org/add-ons/devkit/) 4.7.2
 * [Vagrant](http://vagrantup.com/) 1.7.2
 * [Terraform](http://terraform.io/) 0.3.5

--- a/Rakefile
+++ b/Rakefile
@@ -156,9 +156,9 @@ def reset_git_user
 end
 
 def pre_packaging_checks
-  chefdk_gem_dir = "#{BUILD_DIR}/home/.chefdk/gem/ruby/2.0.0"
-  if not Dir[chefdk_gem_dir].empty?
-    raise "beware: gem binaries in '#{chefdk_gem_dir}/bin' might use an absolute path to ruby.exe!"
+  chefdk_gem_bindir = "#{BUILD_DIR}/home/.chefdk/gem/ruby/2.0.0/bin"
+  if not Dir[chefdk_gem_bindir].empty?
+    raise "beware: gem binaries in '#{chefdk_gem_bindir}' might use an absolute path to ruby.exe!"
   end 
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -155,6 +155,13 @@ def reset_git_user
   end
 end
 
+def pre_packaging_checks
+  chefdk_gem_dir = "#{BUILD_DIR}/home/.chefdk/gem/ruby/2.0.0"
+  if not Dir[chefdk_gem_dir].empty?
+    raise "beware: gem binaries in '#{chefdk_gem_dir}/bin' might use an absolute path to ruby.exe!"
+  end 
+end
+
 def install_sublime_packagecontrol
   target_dir = "#{BUILD_DIR}/tools/sublimetext2/Data/Installed Packages"
   FileUtils.mkdir_p target_dir
@@ -164,6 +171,7 @@ def install_sublime_packagecontrol
 end
 
 def assemble_kitchen
+  pre_packaging_checks
   reset_git_user
   pack BUILD_DIR, "#{TARGET_DIR}/bills-kitchen-#{VERSION}.7z"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -101,7 +101,7 @@ def download_tools
     %w{ dl.bintray.com/mitchellh/terraform/terraform_0.3.6_windows_amd64.zip                                terraform },
     %w{ dl.bintray.com/mitchellh/packer/packer_0.7.5_windows_amd64.zip                                      packer },
     %w{ dl.bintray.com/mitchellh/consul/0.4.1_windows_386.zip                                               consul },
-    %w{ opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.3.5-1.msi                  chef-dk }
+    %w{ opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.3.6-1.msi                  chef-dk }
   ]
   .each do |host_and_path, target_dir, includes = ''|
     download_and_unpack "http://#{host_and_path}", "#{BUILD_DIR}/tools/#{target_dir}", includes.split('|')    

--- a/Rakefile
+++ b/Rakefile
@@ -115,10 +115,14 @@ def move_chefdk
 end
 
 def fix_chefdk
+  Dir.glob("#{BUILD_DIR}/tools/chefdk/embedded/bin/*.bat").each do |file|
+    # ensure omnibus / chef-dk use the embedded ruby, see opscode/chef#1512
+    File.write(file, File.read(file).gsub('@"C:\opscode\chefdk\embedded\bin\ruby.exe" "%~dpn0" %*', '@"%~dp0ruby.exe" "%~dpn0" %*'))
+  end
   # XXX: why are these .bat files even in there? -- the gem .bats should be in embedded/bin
   Dir.glob("#{BUILD_DIR}/tools/chefdk/embedded/lib/ruby/gems/2.0.0/bin/*.bat").each do |file|
     # ensure omnibus / chef-dk use the embedded ruby, see opscode/chef#1512
-    File.write(file, File.read(file).gsub('@"%~dp0ruby.exe" "%~dpn0" %*', '@"%~dp0\..\..\..\..\..\bin\ruby.exe" "%~dpn0" %*'))
+    File.write(file, File.read(file).gsub('@"C:\opscode\chefdk\embedded\bin\ruby.exe" "%~dpn0" %*', '@"%~dp0\..\..\..\..\..\bin\ruby.exe" "%~dpn0" %*'))
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -115,15 +115,6 @@ def move_chefdk
 end
 
 def fix_chefdk
-  Dir.glob("#{BUILD_DIR}/tools/chefdk/bin/*.bat").each do |file|
-    # ensure omnibus / chef-dk use the embedded ruby, see opscode/chef#1512
-    File.write(file, File.read(file).gsub('@"ruby.exe" "%~dpn0"', '@"%~dp0\..\embedded\bin\ruby.exe" "%~dpn0"'))
-    # fix paths if chefdk is intalled anywhere other than c:\opscode, see opscode/chef-dk#68
-    file2 = file.sub(/\.bat$/, '')
-    File.write(file2, File.read(file2).gsub(/Kernel.load '(.*)'/, "Kernel.load \"\\1\""))
-    File.write(file2, File.read(file2).gsub('C:/opscode/chefdk', '#{File.expand_path(File.dirname(__FILE__))}/..'))
-  end
-
   # XXX: why are these .bat files even in there? -- the gem .bats should be in embedded/bin
   Dir.glob("#{BUILD_DIR}/tools/chefdk/embedded/lib/ruby/gems/2.0.0/bin/*.bat").each do |file|
     # ensure omnibus / chef-dk use the embedded ruby, see opscode/chef#1512

--- a/files/home/.bundle/config
+++ b/files/home/.bundle/config
@@ -1,3 +1,4 @@
 ---
+BUNDLE_PATH: ~/.chefdk/gem/ruby/2.0.0
 BUNDLE_JOBS: 16
 BUNDLE_RETRY: 3

--- a/files/home/.gemrc
+++ b/files/home/.gemrc
@@ -1,4 +1,0 @@
-# ensure that gems are NOT installed to ~/.chefdk/gem but rather 
-# to tools/chefdk/embedded/lib (does not work on windows otherwise)
-update: --no-user-install
-install: --no-user-install

--- a/files/set-env.bat
+++ b/files/set-env.bat
@@ -20,6 +20,7 @@ set TERRAFORMDIR=%SCRIPT_DIR%tools\terraform
 set PACKERDIR=%SCRIPT_DIR%tools\packer
 set CONSULDIR=%SCRIPT_DIR%tools\consul
 set CHEFDKDIR=%SCRIPT_DIR%tools\chefdk
+set CHEFDKHOMEDIR=%SCRIPT_DIR%home\.chefdk
 
 :: inject clink into current cmd.exe
 :: call %CLINKDIR%\clink.bat inject
@@ -32,8 +33,14 @@ set GITDIR=%SCRIPT_DIR%tools\portablegit
 set HOME=%SCRIPT_DIR%home
 
 :: Chef-DK embedded Ruby is now the primary one!
-:: see http://jtimberman.housepub.org/blog/2014/04/30/chefdk-and-ruby/
-set RUBYDIR=%CHEFDKDIR%\embedded
+:: see: http://jtimberman.housepub.org/blog/2014/04/30/chefdk-and-ruby/
+:: see: `chef shell-init powershell`
+set GEM_ROOT=%CHEFDKDIR%\embedded\lib\ruby\gems\2.0.0
+set GEM_HOME=%CHEFDKHOMEDIR%\gem\ruby\2.0.0
+set GEM_PATH=%GEM_HOME%;%GEM_ROOT%
+:: that's how the PATH entries are generated for chef shell-init
+set CHEFDK_PATH_ENTRIES=%CHEFDKDIR%\bin;%CHEFDKHOMEDIR%\gem\ruby\2.0.0\bin;%CHEFDKDIR%\embedded\bin
+
 
 :: prompt for .gitconfig username/email
 FOR /F "usebackq tokens=*" %%a IN (`cmd /C %GITDIR%\cmd\git config --get user.name`) DO SET GIT_CONF_USERNAME=%%a
@@ -79,7 +86,10 @@ set CYGWIN=nodosfilewarning
 
 :: show the environment
 echo CHEFDKDIR=%CHEFDKDIR%
-echo RUBYDIR=%RUBYDIR%
+echo CHEFDKHOMEDIR=%CHEFDKHOMEDIR%
+echo GEM_ROOT=%GEM_ROOT%
+echo GEM_HOME=%GEM_HOME%
+echo GEM_PATH=%GEM_PATH%
 echo DEVKITDIR=%DEVKITDIR%
 echo VBOX_USER_HOME=%VBOX_USER_HOME%
 echo VBOX_INSTALL_PATH=%VBOX_INSTALL_PATH%
@@ -106,4 +116,4 @@ echo HTTP_PROXY=%HTTP_PROXY%
 @doskey vi=START "Sublime Text 2" sublime_text $*
 @doskey be=bundle exec $*
 
-set PATH=%CHEFDKDIR%\bin;%RUBYDIR%\bin;%CONSULDIR%;%PACKERDIR%;%TERRAFORMDIR%;%VAGRANTDIR%\bin;%GITDIR%\cmd;%KDIFF3DIR%;%CYGWINRSYNCDIR%;%CYGWINSSHDIR%;%VAGRANTDIR%\embedded\bin;%CONEMUDIR%;%SUBLIMEDIR%;%PUTTYDIR%;%VBOX_MSI_INSTALL_PATH%;%VBOX_INSTALL_PATH%;%PATH%
+set PATH=%CHEFDK_PATH_ENTRIES%;%CONSULDIR%;%PACKERDIR%;%TERRAFORMDIR%;%VAGRANTDIR%\bin;%GITDIR%\cmd;%KDIFF3DIR%;%CYGWINRSYNCDIR%;%CYGWINSSHDIR%;%VAGRANTDIR%\embedded\bin;%CONEMUDIR%;%SUBLIMEDIR%;%PUTTYDIR%;%VBOX_MSI_INSTALL_PATH%;%VBOX_INSTALL_PATH%;%PATH%

--- a/files/set-env.ps1
+++ b/files/set-env.ps1
@@ -14,6 +14,7 @@ $env:TERRAFORMDIR = Join-Path $pwd tools\terraform
 $env:PACKERDIR = Join-Path $pwd tools\packer
 $env:CONSULDIR = Join-Path $pwd tools\consul
 $env:CHEFDKDIR = Join-Path $pwd tools\chefdk
+$env:CHEFDKHOMEDIR = Join-Path $pwd home\.chefdk
 
 ## inject clink into current cmd.exe
 invoke-expression ((Join-Path $env:CLINKDIR clink.bat) inject)
@@ -24,8 +25,14 @@ invoke-expression (Join-Path $env:DEVKITDIR devkitvars.bat)
 $env:HOME = Join-Path $pwd home
 
 ## Chef-DK embedded Ruby is now the primary one!
-## see http://jtimberman.housepub.org/blog/2014/04/30/chefdk-and-ruby/
-$env:RUBYDIR = Join-Path $env:CHEFDKDIR embedded
+## see: http://jtimberman.housepub.org/blog/2014/04/30/chefdk-and-ruby/
+## see: `chef shell-init powershell`
+$env:GEM_ROOT = Join-Path $env:CHEFDKDIR embedded\lib\ruby\gems\2.0.0
+$env:GEM_HOME = Join-Path $env:CHEFDKHOMEDIR gem\ruby\2.0.0
+$env:GEM_PATH = "$env:GEM_HOME;$env:GEM_ROOT"
+## that's how the PATH entries are generated for chef shell-init
+$env:CHEFDK_PATH_ENTRIES = "$env:CHEFDKDIR\bin;$env:CHEFDKHOMEDIR\gem\ruby\2.0.0\bin;$env:CHEFDKDIR\embedded\bin"
+
 
 if($env:GITDIR -eq $NULL) {
 	$env:GITDIR = Join-Path $pwd tools\portablegit
@@ -83,6 +90,10 @@ $env:SSL_CERT_FILE = Join-Path $env:HOME "cacert.pem"
 # show the environment
 Write-Host "CHEFDKDIR=$env:CHEFDKDIR"
 Write-Host "RUBYDIR=$env:RUBYDIR"
+Write-Host "CHEFDKHOMEDIR=$env:CHEFDKHOMEDIR"
+Write-Host "GEM_ROOT=$env:GEM_ROOT"
+Write-Host "GEM_HOME=$env:GEM_HOME"
+Write-Host "GEM_PATH=$env:GEM_PATH"
 Write-Host "DEVKITDIR=$env:DEVKITDIR"
 Write-Host "VBOX_USER_HOME=$env:VBOX_USER_HOME"
 Write-Host "VBOX_INSTALL_PATH=$env:VBOX_INSTALL_PATH"
@@ -106,4 +117,4 @@ Write-Host "HTTP_PROXY=$env:HTTP_PROXY"
 set-alias vi "sublime_text";
 set-alias be "bundle exec"; 
 
-$env:Path = "$env:CHEFDKDIR\bin;$env:RUBYDIR\bin;$env:CONSULDIR;$env:PACKERDIR;$env:TERRAFORMDIR;$env:VAGRANTDIR\bin;$env:KDIFF3DIR;$env:CYGWINRSYNCDIR;$env:CYGWINSSHDIR;$env:VAGRANTDIR\embedded\bin;$env:CONEMUDIR;$env:SUBLIMEDIR;$env:PUTTYDIR;$env:VBOX_INSTALL_PATH;$env:Path"
+$env:Path = "$env:CHEFDK_PATH_ENTRIES;$env:CONSULDIR;$env:PACKERDIR;$env:TERRAFORMDIR;$env:VAGRANTDIR\bin;$env:KDIFF3DIR;$env:CYGWINRSYNCDIR;$env:CYGWINSSHDIR;$env:VAGRANTDIR\embedded\bin;$env:CONEMUDIR;$env:SUBLIMEDIR;$env:PUTTYDIR;$env:VBOX_INSTALL_PATH;$env:Path"

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -3,6 +3,7 @@ BUILD_DIR=File.expand_path('./target/build')
 CHEFDK_RUBY = "#{BUILD_DIR}/tools/chefdk/embedded"
 CHEFDK_HOME = "#{BUILD_DIR}/home/.chefdk"
 VAGRANT_RUBY = "#{BUILD_DIR}/tools/vagrant/HashiCorp/Vagrant/embedded"
+VAGRANT_HOME = "#{BUILD_DIR}/home/.vagrant.d"
 
 # enable :should syntax for rspec 3
 RSpec.configure do |config|

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -6,8 +6,8 @@ describe "bills kitchen" do
   include Helpers
 
   describe "tools" do
-    it "installs ChefDK 0.3.5" do
-      run_cmd("chef -v").should match('Chef Development Kit Version: 0.3.5')
+    it "installs ChefDK 0.3.6" do
+      run_cmd("chef -v").should match('Chef Development Kit Version: 0.3.6')
     end
     it "installs Vagrant 1.7.2" do
       run_cmd("vagrant -v").should match('1.7.2')
@@ -86,8 +86,8 @@ describe "bills kitchen" do
     end
 
     describe "chefdk ruby" do
-      it "installs Chef 11.18.0.rc.1" do
-        run_cmd("knife -v").should match('Chef: 11.18.0.rc.1')
+      it "installs Chef 11.18.0" do
+        run_cmd("knife -v").should match('Chef: 11.18.0')
       end
       it "uses the ChefDK embedded gemdir" do
         run_cmd("#{CHEFDK_RUBY}/bin/gem environment gemdir").should match("#{CHEFDK_RUBY}/lib/ruby/gems/2.0.0")

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -95,6 +95,10 @@ describe "bills kitchen" do
       it "has RubyGems > 2.4.1 installed (fixes opscode/chef-dk#242)" do
         run_cmd("gem -v").should match('2.4.4')
       end
+      it "ships with an empty $HOME/.chefdk directory" do
+        # because since RubyGems > 2.4.1 the ruby path in here is absolute!
+        Dir["#{CHEFDK_HOME}/gem/ruby/2.0.0/"].should be_empty
+      end
       it "has ChefDK verified to work via `chef verify`" do
         cmd_succeeds "chef verify"
       end

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -89,15 +89,15 @@ describe "bills kitchen" do
       it "installs Chef 11.18.0" do
         run_cmd("knife -v").should match('Chef: 11.18.0')
       end
-      it "uses the ChefDK embedded gemdir" do
-        run_cmd("#{CHEFDK_RUBY}/bin/gem environment gemdir").should match("#{CHEFDK_RUBY}/lib/ruby/gems/2.0.0")
-      end
       it "has RubyGems > 2.4.1 installed (fixes opscode/chef-dk#242)" do
         run_cmd("gem -v").should match('2.4.4')
       end
-      it "ships with an empty $HOME/.chefdk directory" do
+      it "uses $HOME/.chefdk as the gemdir" do
+        run_cmd("#{CHEFDK_RUBY}/bin/gem environment gemdir").should match("#{CHEFDK_HOME}/gem/ruby/2.0.0")
+      end
+      it "does not have any binaries in the $HOME/.chefdk gemdir preinstalled when we ship it" do
         # because since RubyGems > 2.4.1 the ruby path in here is absolute!
-        Dir["#{CHEFDK_HOME}/gem/ruby/2.0.0/"].should be_empty
+        Dir["#{CHEFDK_HOME}/gem/ruby/2.0.0/bin"].should be_empty
       end
       it "has ChefDK verified to work via `chef verify`" do
         cmd_succeeds "chef verify"
@@ -114,9 +114,6 @@ describe "bills kitchen" do
     end
 
     describe "vagrant ruby" do
-      it "uses the vagrant embedded gemdir" do
-        run_cmd("#{VAGRANT_RUBY}/bin/gem environment gemdir").should match("#{VAGRANT_RUBY}/lib/ruby/gems/2.0.0")
-      end
       it "has 'vagrant-toplevel-cookbooks (0.2.3)' plugin installed" do
         vagrant_plugin_installed "vagrant-toplevel-cookbooks", "0.2.3"
       end
@@ -128,6 +125,9 @@ describe "bills kitchen" do
       end
       it "has 'vagrant-berkshelf (4.0.2)' plugin installed" do
         vagrant_plugin_installed "vagrant-berkshelf", "4.0.2"
+      end
+      it "installed vagrant plugins $HOME/.vagrant.d" do
+        Dir.entries("#{VAGRANT_HOME}/gems/gems").should include('vagrant-toplevel-cookbooks-0.2.3')
       end
     end
   end

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -92,11 +92,8 @@ describe "bills kitchen" do
       it "uses the ChefDK embedded gemdir" do
         run_cmd("#{CHEFDK_RUBY}/bin/gem environment gemdir").should match("#{CHEFDK_RUBY}/lib/ruby/gems/2.0.0")
       end
-      it "does NOT install gems into $HOME/.chefdk" do
-        gem_env = run_cmd("#{CHEFDK_RUBY}/bin/gem environment")
-        gem_env.should match('"update" => "--no-user-install"')
-        gem_env.should match('"install" => "--no-user-install"')
-        Dir["#{CHEFDK_HOME}/gem/ruby/2.0.0/"].should be_empty
+      it "has RubyGems > 2.4.1 installed (fixes opscode/chef-dk#242)" do
+        run_cmd("gem -v").should match('2.4.4')
       end
       it "has ChefDK verified to work via `chef verify`" do
         cmd_succeeds "chef verify"


### PR DESCRIPTION
Updates to the latest ChefDK 0.3.6, including:

 * chefdk version update to 0.3.6
 * remove some unncessary fixes from `#fix_chefdk` method in Rakefile
 * mimic `chef shell-init` by setting env vars accordingly
 * restoring original behaviour of using `$HOME/.chefdk` for user installed gems (see #71)
 * adapt tests where necessary