### PR TITLE
Update to ChefDK 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 
 # 2.4 (unreleased)
 
- * ...
+ * tool updates:
+  * update to ChefDK 0.4.0
 
 # 2.3 (January 23, 2015)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A [DevPack](http://blog.tknerr.de/blog/2014/10/09/devpack-philosophy-aka-works-o
 
 The main tools for cooking with Chef / Vagrant:
 
-* [Chef-DK](http://www.getchef.com/downloads/chef-dk/windows/) 0.3.6, with embedded [Ruby](http://rubyinstaller.org/downloads/) 2.0.0
+* [Chef-DK](http://www.getchef.com/downloads/chef-dk/windows/) 0.4.0, with embedded [Ruby](http://rubyinstaller.org/downloads/) 2.0.0
 * [DevKit](http://rubyinstaller.org/add-ons/devkit/) 4.7.2
 * [Vagrant](http://vagrantup.com/) 1.7.2
 * [Terraform](http://terraform.io/) 0.3.5

--- a/Rakefile
+++ b/Rakefile
@@ -101,7 +101,7 @@ def download_tools
     %w{ dl.bintray.com/mitchellh/terraform/terraform_0.3.6_windows_amd64.zip                                terraform },
     %w{ dl.bintray.com/mitchellh/packer/packer_0.7.5_windows_amd64.zip                                      packer },
     %w{ dl.bintray.com/mitchellh/consul/0.4.1_windows_386.zip                                               consul },
-    %w{ opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.3.6-1.msi                  chef-dk }
+    %w{ opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.4.0-1.msi                  chef-dk }
   ]
   .each do |host_and_path, target_dir, includes = ''|
     download_and_unpack "http://#{host_and_path}", "#{BUILD_DIR}/tools/#{target_dir}", includes.split('|')    

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -6,8 +6,8 @@ describe "bills kitchen" do
   include Helpers
 
   describe "tools" do
-    it "installs ChefDK 0.3.6" do
-      run_cmd("chef -v").should match('Chef Development Kit Version: 0.3.6')
+    it "installs ChefDK 0.4.0" do
+      run_cmd("chef -v").should match('Chef Development Kit Version: 0.4.0')
     end
     it "installs Vagrant 1.7.2" do
       run_cmd("vagrant -v").should match('1.7.2')
@@ -86,8 +86,8 @@ describe "bills kitchen" do
     end
 
     describe "chefdk ruby" do
-      it "installs Chef 11.18.0" do
-        run_cmd("knife -v").should match('Chef: 11.18.0')
+      it "installs Chef 12.0.3" do
+        run_cmd("knife -v").should match('Chef: 12.0.3')
       end
       it "has RubyGems > 2.4.1 installed (fixes opscode/chef-dk#242)" do
         run_cmd("gem -v").should match('2.4.4')
@@ -102,8 +102,8 @@ describe "bills kitchen" do
       it "has ChefDK verified to work via `chef verify`" do
         cmd_succeeds "chef verify"
       end
-      it "has 'bundler (1.7.5)' gem installed" do
-        gem_installed "bundler", "1.7.5"
+      it "has 'bundler (1.7.12)' gem installed" do
+        gem_installed "bundler", "1.7.12"
       end
       it "has 'knife-audit (0.2.0)' plugin installed" do
         knife_plugin_installed "knife-audit", "0.2.0"


### PR DESCRIPTION
This PR simply updates to the latest ChefDK 0.4.0

All integration & acceptance tests pass.