### PR TITLE
Enable caching of busser gems only if we are in a test-kitchen run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 # 2.4 (unreleased)
 
  * tool updates:
-  * update to ChefDK 0.4.0
+  * update to ChefDK 0.5.0-rc.2
   * update to Terraform 0.3.7
   * update to Consul 0.5.0
   * update to ConEmu 20150305
@@ -23,6 +23,8 @@
   * `language-chef` - chef specific syntax highlighting and snippets (see here [how to enable it](https://github.com/darron/language-chef/issues/3#issuecomment-87335835))
   * `language-batchfile` - syntax higlighting for .bat files
   * `autocomplete-plus` - for better auto-completion
+  * `autocomplete-snippets` - to enable auto-completion for snippets
+
   * `autocomplete-snippets` - to enable auto-completion for snippets
 
 

--- a/files/home/.kitchen/config.yml
+++ b/files/home/.kitchen/config.yml
@@ -1,0 +1,5 @@
+---
+driver:
+  name: vagrant
+  # run provisioners when VM is created (e.g. from global Vagrantfile)
+  provision: true

--- a/files/home/.vagrant.d/Vagrantfile
+++ b/files/home/.vagrant.d/Vagrantfile
@@ -9,9 +9,21 @@ Vagrant.configure("2") do |config|
     # cache bussers, but only if we detect a test-kitchen run
     # see https://github.com/tknerr/bills-kitchen/pull/78
     if Dir.pwd.include? ".kitchen/kitchen-vagrant/"
+
       config.cache.enable :generic, {
-        "busser" => { cache_dir: "/tmp/busser/gems" }
+        # for test-kitchen =< 1.3
+        "busser-gemcache" => { cache_dir: "/tmp/busser/gems/cache" },
+        # for test-kitchen >= 1.4
+        "verifier-gemcache" => { cache_dir: "/tmp/verifier/gems/cache" }
       }
+
+      # fix permissions 
+      # see https://github.com/mitchellh/vagrant/issues/2257
+      # see https://github.com/test-kitchen/test-kitchen/issues/671
+      config.vm.provision "shell", inline: <<-EOF
+        chown -R vagrant:vagrant /tmp/busser
+        chown -R vagrant:vagrant /tmp/verifier
+      EOF
     end
   end
 end

--- a/files/home/.vagrant.d/Vagrantfile
+++ b/files/home/.vagrant.d/Vagrantfile
@@ -7,6 +7,7 @@ Vagrant.configure("2") do |config|
     config.cache.scope = :box
 
     # cache bussers, but only if we detect a test-kitchen run
+    # see https://github.com/tknerr/bills-kitchen/pull/78
     if Dir.pwd.include? ".kitchen/kitchen-vagrant/"
       config.cache.enable :generic, {
         "busser" => { cache_dir: "/tmp/busser/gems" }

--- a/files/home/.vagrant.d/Vagrantfile
+++ b/files/home/.vagrant.d/Vagrantfile
@@ -6,9 +6,11 @@ Vagrant.configure("2") do |config|
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box
 
-    # cache bussers for test-kitchen
-    config.cache.enable :generic, {
-      "busser" => { cache_dir: "/tmp/busser/gems" }
-    }
+    # cache bussers, but only if we detect a test-kitchen run
+    if Dir.pwd.include? ".kitchen/kitchen-vagrant/"
+      config.cache.enable :generic, {
+        "busser" => { cache_dir: "/tmp/busser/gems" }
+      }
+    end
   end
 end


### PR DESCRIPTION
This is a hack-like workaround to limit caching of the generic busser gems cache to occasions when we are running as part of a test-kitchen run.

We use `Dir.pwd` to guess whether we are in a kitchenci generated directory and thus can assume we are running in a kitchenci run with the kitchen-vagrant plugin.

*Why* doing this? Because

1. we only need it in this case and 
2. it alleviates problems with windows guests (see https://github.com/fgrehm/vagrant-cachier/issues/137)