### PR TITLE
Update to Chefdk 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 # 2.4 (unreleased)
 
  * tool updates:
-  * update to ChefDK 0.4.0
+  * update to ChefDK 0.5.0-rc.2
   * update to Terraform 0.3.7
   * update to Consul 0.5.0
   * update to ConEmu 20150305

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 A [DevPack](http://blog.tknerr.de/blog/2014/10/09/devpack-philosophy-aka-works-on-your-machine/) with all you (or Bill Gates would) need for cooking with Chef and Vagrant on Windows, shrink-wrapped in a portable package.
 
-![Bill's Kitchen Screenshot](https://raw.github.com/tknerr/bills-kitchen/master/doc/bills_kitchen_screenshot.png) 
+![Bill's Kitchen Screenshot](https://raw.github.com/tknerr/bills-kitchen/master/doc/bills_kitchen_screenshot.png)
 
 ## Installation and Usage
 
@@ -22,12 +22,12 @@ Using Bill's Kitchen itself is fairly simple. There is nothing to install, just 
 
 The main tools for cooking with Chef / Vagrant:
 
-* [Chef-DK](http://www.getchef.com/downloads/chef-dk/windows/) 0.4.0, with embedded [Ruby](http://rubyinstaller.org/downloads/) 2.0.0
+* [Chef-DK](http://www.getchef.com/downloads/chef-dk/windows/) 0.5.0, with embedded [Ruby](http://rubyinstaller.org/downloads/) 2.0.0
 * [DevKit](http://rubyinstaller.org/add-ons/devkit/) 4.7.2
 * [Vagrant](http://vagrantup.com/) 1.7.2
-* [Terraform](http://terraform.io/) 0.3.5
+* [Terraform](http://terraform.io/) 0.3.7
 * [Packer](http://packer.io/) 0.7.5
-* [Consul](http://consul.io/) 0.4.1
+* [Consul](http://consul.io/) 0.5.0
 
 ### Plugins
 
@@ -75,7 +75,7 @@ The following changes are applied to your environment by running `W:\set-env.bat
 Registered doskey aliases:
 
 * run `be <command>` for `bundle exec <command>`
-* run `vi <file_or_dir>` for `atom <file_or_dir>` 
+* run `vi <file_or_dir>` for `atom <file_or_dir>`
 
 ### Examples
 

--- a/Rakefile
+++ b/Rakefile
@@ -105,7 +105,7 @@ def download_tools
     %w{ dl.bintray.com/mitchellh/terraform/terraform_0.3.7_windows_amd64.zip                                terraform },
     %w{ dl.bintray.com/mitchellh/packer/packer_0.7.5_windows_amd64.zip                                      packer },
     %w{ dl.bintray.com/mitchellh/consul/0.5.0_windows_386.zip                                               consul },
-    %w{ opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.4.0-1.msi                  chef-dk }
+    %w{ opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.5.0-rc.2-1.msi             chef-dk }
   ]
   .each do |host_and_path, target_dir, includes = ''|
     download_and_unpack "http://#{host_and_path}", "#{BUILD_DIR}/tools/#{target_dir}", includes.split('|')

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -6,8 +6,8 @@ describe "bills kitchen" do
   include Helpers
 
   describe "tools" do
-    it "installs ChefDK 0.4.0" do
-      run_cmd("chef -v").should match('Chef Development Kit Version: 0.4.0')
+    it "installs ChefDK 0.5.0.rc.2" do
+      run_cmd("chef -v").should match('Chef Development Kit Version: 0.5.0.rc.2')
     end
     it "installs Vagrant 1.7.2" do
       run_cmd("vagrant -v").should match('1.7.2')
@@ -95,8 +95,8 @@ describe "bills kitchen" do
     end
 
     describe "chefdk ruby" do
-      it "installs Chef 12.0.3" do
-        run_cmd("knife -v").should match('Chef: 12.0.3')
+      it "installs Chef 12.2.0" do
+        run_cmd("knife -v").should match('Chef: 12.2.0')
       end
       it "has RubyGems > 2.4.1 installed (fixes opscode/chef-dk#242)" do
         run_cmd("gem -v").should match('2.4.4')


### PR DESCRIPTION
This PR is here to update the ChefDK to version 0.5.0. 

Currently 0.5.0-rc2 is out. Once the final version is out and everything works ok we can merge it. 