### PR TITLE
Add env var to disable cachier in the global Vagrantfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
  * improvements:
    * init the shell for docker in the `set-env` scripts rather than in `b2d-start.bat`
-   * add `VAGRANT_CACHIER_DISABLED` env var to disable vagrant-cachier in the global Vagrantfile ([#98](https://github.com/tknerr/bills-kitchen/issues/98)) 
+   * add `GLOBAL_VAGRANT_CACHIER_DISABLED` env var to allow for disabling vagrant-cachier in the global Vagrantfile ([#98](https://github.com/tknerr/bills-kitchen/pull/98)) 
  * bug fixes:
    * make `bundle` and other gem binaries work in `git-bash` too [#97](https://github.com/tknerr/bills-kitchen/issues/97)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,13 @@
 
  * improvements:
    * init the shell for docker in the `set-env` scripts rather than in `b2d-start.bat`
+   * add `VAGRANT_CACHIER_DISABLED` env var to disable vagrant-cachier in the global Vagrantfile ([#98](https://github.com/tknerr/bills-kitchen/issues/98)) 
  * bug fixes:
    * make `bundle` and other gem binaries work in `git-bash` too [#97](https://github.com/tknerr/bills-kitchen/issues/97)
 
 # 3.0-rc2 (April 20, 2015)
 
- * new tools:
+ * new tools:h
   * added boot2docker-cli 1.6.0
   * added docker client 1.6.0
   * added `b2d-start.bat` and `b2d-stop.bat` for setting up the Docker environment (see [#95](https://github.com/tknerr/bills-kitchen/pull/95))

--- a/files/home/.vagrant.d/Vagrantfile
+++ b/files/home/.vagrant.d/Vagrantfile
@@ -3,7 +3,7 @@
 Vagrant.configure("2") do |config|
 
   # enable cachier globally
-  if Vagrant.has_plugin?("vagrant-cachier")
+  if !ENV["VAGRANT_CACHIER_DISABLED"] && Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box
 
     # cache bussers, but only if we detect a test-kitchen run

--- a/files/home/.vagrant.d/Vagrantfile
+++ b/files/home/.vagrant.d/Vagrantfile
@@ -3,7 +3,7 @@
 Vagrant.configure("2") do |config|
 
   # enable cachier globally
-  if !ENV["VAGRANT_CACHIER_DISABLED"] && Vagrant.has_plugin?("vagrant-cachier")
+  if !ENV["GLOBAL_VAGRANT_CACHIER_DISABLED"] && Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box
 
     # cache bussers, but only if we detect a test-kitchen run


### PR DESCRIPTION
Sometimes a vagrant provider is not compatible with vagrant-cachier.

This conflicts with our approach to transparently enable cachier via the global `~/.vagrant.d/Vagrantfile`. 

Since such incompatibiliies are rarely the case under our controlled devpack environment, we keep cachier enabled (sane default), but allow to disable it via the `GLOBAL_VAGRANT_CACHIER_DISABLED` env var:

 * if set, cachier will be disabled in the global Vagrantfile (but can still be enabled on a per project basis)
 * if unset, cachier will be enabled by default via the global Vagrantfile

Related incompatibility:
https://github.com/fgrehm/vagrant-cachier/issues/142