### PR TITLE
Patch Vagrant for Remote Docker Host Support (Experimental)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
    * make the `b2d-start.bat` and `b2d-stop.bat` scripts more resilient
    * add `b2d` shortcut doskey alias for `boot2docker`
    * add `GLOBAL_VAGRANT_CACHIER_DISABLED` env var to allow for disabling vagrant-cachier in the global Vagrantfile ([#98](https://github.com/tknerr/bills-kitchen/pull/98))
+   * patch vagrant with remote docker host support; conditionally enable it `b2d-start` and disable it in `b2d-stop` (experimental, see [#100](https://github.com/tknerr/bills-kitchen/pull/100git)) 
  * bug fixes:
    * make `bundle` and other gem binaries work in `git-bash` too [#97](https://github.com/tknerr/bills-kitchen/issues/97)
 

--- a/files/tools/docker/b2d-start.bat
+++ b/files/tools/docker/b2d-start.bat
@@ -45,4 +45,8 @@ boot2docker ssh -- sudo mount -t vboxsf billskitchen %BK_ROOT_CYGPATH%
 
 ENDLOCAL
 
+
+:: experimental: enable remote docker host patch in vagrant when b2d is started
+set VAGRANT_DOCKER_REMOTE_HOST_PATCH=1
+
 :end

--- a/files/tools/docker/b2d-stop.bat
+++ b/files/tools/docker/b2d-stop.bat
@@ -16,4 +16,8 @@ boot2docker down 2>NUL || boot2docker down
 echo Removing shared folder "billskitchen"
 VBoxManage sharedfolder remove "boot2docker-vm" --name "billskitchen"
 
+
+:: disable experimental remote docker host patch when b2d is stopped
+set VAGRANT_DOCKER_REMOTE_HOST_PATCH=0
+
 :end

--- a/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/action/create.rb
+++ b/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/action/create.rb
@@ -1,0 +1,156 @@
+module VagrantPlugins
+  module DockerProvider
+    module Action
+      class Create
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          @env             = env
+          @machine         = env[:machine]
+          @provider_config = @machine.provider_config
+          @machine_config  = @machine.config
+          @driver          = @machine.provider.driver
+
+          params = create_params
+
+          # If we're running a single command, we modify the params a bit
+          if env[:machine_action] == :run_command
+            # Use the command that is given to us
+            params[:cmd] = env[:run_command]
+
+            # Don't detach, we want to watch the command run
+            params[:detach] = false
+
+            # No ports should be shared to the host
+            params[:ports] = []
+
+            # Allocate a pty if it was requested
+            params[:pty] = true if env[:run_pty]
+
+            # Remove container after execution
+            params[:rm] = true if env[:run_rm]
+
+            # Name should be unique
+            params[:name] = "#{params[:name]}_#{Time.now.to_i}"
+
+            # We link to our original container
+            # TODO
+          end
+
+          env[:ui].output(I18n.t("docker_provider.creating"))
+          env[:ui].detail("  Name: #{params[:name]}")
+
+          env[:ui].detail(" Image: #{params[:image]}")
+          if params[:cmd] && !params[:cmd].empty?
+            env[:ui].detail("   Cmd: #{params[:cmd].join(" ")}")
+          end
+          params[:volumes].each do |volume|
+            env[:ui].detail("Volume: #{volume}")
+          end
+          params[:ports].each do |pair|
+            env[:ui].detail("  Port: #{pair}")
+          end
+          params[:links].each do |name, other|
+            env[:ui].detail("  Link: #{name}:#{other}")
+          end
+
+          if env[:machine_action] != :run_command
+            # For regular "ups" create it and get the CID
+            cid = @driver.create(params)
+            env[:ui].detail(" \n"+I18n.t(
+              "docker_provider.created", id: cid[0...16]))
+            @machine.id = cid
+          elsif params[:detach]
+            env[:ui].detail(" \n"+I18n.t("docker_provider.running_detached"))
+          else
+            ui_opts = {}
+
+            # If we're running with a pty, we want the output to look as
+            # authentic as possible. We don't prefix things and we don't
+            # output a newline.
+            if env[:run_pty]
+              ui_opts[:prefix] = false
+              ui_opts[:new_line] = false
+            end
+
+            # For run commands, we run it and stream back the output
+            env[:ui].detail(" \n"+I18n.t("docker_provider.running")+"\n ")
+            @driver.create(params, stdin: env[:run_pty]) do |type, data|
+              env[:ui].detail(data.chomp, **ui_opts)
+            end
+          end
+
+          @app.call(env)
+        end
+
+        def create_params
+          container_name = @provider_config.name
+          if !container_name
+            container_name = "#{@env[:root_path].basename.to_s}_#{@machine.name}"
+            container_name.gsub!(/[^-a-z0-9_]/i, "")
+            container_name << "_#{Time.now.to_i}"
+          end
+
+          image = @env[:create_image]
+          image ||= @provider_config.image
+
+          links = []
+          @provider_config._links.each do |link|
+            parts = link.split(":", 2)
+            links << parts
+          end
+
+          {
+            cmd:        @provider_config.cmd,
+            detach:     true,
+            env:        @provider_config.env,
+            expose:     @provider_config.expose,
+            extra_args: @provider_config.create_args,
+            hostname:   @machine_config.vm.hostname,
+            image:      image,
+            links:      links,
+            name:       container_name,
+            ports:      forwarded_ports(@provider_config.has_ssh),
+            privileged: @provider_config.privileged,
+            pty:        false,
+            volumes:    @provider_config.volumes,
+          }
+        end
+
+        def forwarded_ports(include_ssh=false)
+          mappings = {}
+          random = []
+
+          @machine.config.vm.networks.each do |type, options|
+            next if type != :forwarded_port
+
+            # Don't include SSH if we've explicitly asked not to
+            next if options[:id] == "ssh" && !include_ssh
+
+            # If the guest port is 0, put it in the random group
+            if options[:guest] == 0
+              random << options[:host]
+              next
+            end
+
+            mappings[options[:host]] = options
+          end
+
+          # Build the results
+          result = random.map(&:to_s)
+          result += mappings.values.map do |fp|
+            protocol = ""
+            protocol = "/udp" if fp[:protocol].to_s == "udp"
+            host_ip = ""
+            host_ip = "#{fp[:host_ip]}:" if fp[:host_ip]
+            "#{host_ip}#{fp[:host]}:#{fp[:guest]}#{protocol}"
+          end.compact
+
+          result
+        end
+      end
+    end
+  end
+end

--- a/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/action/create.rb
+++ b/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/action/create.rb
@@ -141,6 +141,11 @@ module VagrantPlugins
           # Build the results
           result = random.map(&:to_s)
           result += mappings.values.map do |fp|
+
+            if ENV['VAGRANT_DOCKER_REMOTE_HOST_PATCH'] == "1"
+              fp[:host_ip] = "0.0.0.0"
+            end
+
             protocol = ""
             protocol = "/udp" if fp[:protocol].to_s == "udp"
             host_ip = ""

--- a/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/provider.rb
+++ b/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/provider.rb
@@ -1,0 +1,181 @@
+require "digest/md5"
+require "fileutils"
+require "thread"
+
+require "log4r"
+
+require "vagrant/util/silence_warnings"
+
+module VagrantPlugins
+  module DockerProvider
+    class Provider < Vagrant.plugin("2", :provider)
+      @@host_vm_mutex = Mutex.new
+
+      def initialize(machine)
+        @logger  = Log4r::Logger.new("vagrant::provider::docker")
+        @machine = machine
+
+        if host_vm?
+          # We need to use a special communicator that proxies our
+          # SSH requests over our host VM to the container itself.
+          @machine.config.vm.communicator = :docker_hostvm
+        end
+      end
+
+      # @see Vagrant::Plugin::V2::Provider#action
+      def action(name)
+        action_method = "action_#{name}"
+        return Action.send(action_method) if Action.respond_to?(action_method)
+        nil
+      end
+
+      # Returns the driver instance for this provider.
+      def driver
+        return @driver if @driver
+        @driver = Driver.new
+
+        # If we are running on a host machine, then we set the executor
+        # to execute remotely.
+        if host_vm?
+          @driver.executor = Executor::Vagrant.new(host_vm)
+        end
+
+        @driver
+      end
+
+      # This returns the {Vagrant::Machine} that is our host machine.
+      # It does not perform any action on the machine or verify it is
+      # running.
+      #
+      # @return [Vagrant::Machine]
+      def host_vm
+        return @host_vm if @host_vm
+
+        vf_path           = @machine.provider_config.vagrant_vagrantfile
+        host_machine_name = @machine.provider_config.vagrant_machine || :default
+        if !vf_path
+          # We don't have a Vagrantfile path set, so we're going to use
+          # the default but we need to copy it into the data dir so that
+          # we don't write into our installation dir (we can't).
+          default_path = File.expand_path("../hostmachine/Vagrantfile", __FILE__)
+          vf_path      = @machine.env.data_dir.join("docker-host", "Vagrantfile")
+          begin
+            @machine.env.lock("docker-provider-hostvm") do
+              vf_path.dirname.mkpath
+              FileUtils.cp(default_path, vf_path)
+            end
+          rescue Vagrant::Errors::EnvironmentLockedError
+            # Lock contention, just retry
+            retry
+          end
+
+          # Set the machine name since we hardcode that for the default
+          host_machine_name = :default
+        end
+
+        # Expand it so that the home directories and so on get processed
+        # properly.
+        vf_path = File.expand_path(vf_path, @machine.env.root_path)
+
+        vf_file = File.basename(vf_path)
+        vf_path = File.dirname(vf_path)
+
+        # Create the env to manage this machine
+        @host_vm = Vagrant::Util::SilenceWarnings.silence! do
+          host_env = Vagrant::Environment.new(
+            cwd: vf_path,
+            home_path: @machine.env.home_path,
+            ui_class: @machine.env.ui_class,
+            vagrantfile_name: vf_file,
+          )
+
+          host_env.machine(
+            host_machine_name,
+            host_env.default_provider(
+              exclude: [:docker],
+              force_default: false,
+            ))
+        end
+
+        @host_vm
+      end
+
+      # This acquires a lock on the host VM.
+      def host_vm_lock
+        hash = Digest::MD5.hexdigest(host_vm.data_dir.to_s)
+
+        # We do a process-level mutex on the outside, since we can
+        # wait for that a short amount of time. Then, we do a process lock
+        # on the inside, which will raise an exception if locked.
+        host_vm_mutex.synchronize do
+          @machine.env.lock(hash) do
+            return yield
+          end
+        end
+      end
+
+      # This is a process-local mutex that can be used by parallel
+      # providers to lock the host VM access.
+      def host_vm_mutex
+        @@host_vm_mutex
+      end
+
+      # This says whether or not Docker will be running within a VM
+      # rather than directly on our system. Docker needs to run in a VM
+      # when we're not on Linux, or not on a Linux that supports Docker.
+      def host_vm?
+        @machine.provider_config.force_host_vm ||
+          !Vagrant::Util::Platform.linux?
+      end
+
+      # Returns the SSH info for accessing the Container.
+      def ssh_info
+        # If the container isn't running, we can't SSH into it
+        return nil if state.id != :running
+
+        network = driver.inspect_container(@machine.id)['NetworkSettings']
+        ip      = network['IPAddress']
+
+        # If we were not able to identify the container's IP, we return nil
+        # here and we let Vagrant core deal with it ;)
+        return nil if !ip
+
+        {
+          host: ip,
+          port: @machine.config.ssh.guest_port
+        }
+      end
+
+      def state
+        state_id = nil
+        state_id = :not_created if !@machine.id
+        state_id = :host_state_unknown if !state_id && \
+          host_vm? && !host_vm.communicate.ready?
+        state_id = :not_created if !state_id && \
+          (!@machine.id || !driver.created?(@machine.id))
+        state_id = driver.state(@machine.id) if @machine.id && !state_id
+        state_id = :unknown if !state_id
+
+        # This is a special pseudo-state so that we don't set the
+        # NOT_CREATED_ID while we're setting up the machine. This avoids
+        # clearing the data dir.
+        state_id = :preparing if @machine.id == "preparing"
+
+        short = state_id.to_s.gsub("_", " ")
+        long  = I18n.t("docker_provider.status.#{state_id}")
+
+        # If we're not created, then specify the special ID flag
+        if state_id == :not_created
+          state_id = Vagrant::MachineState::NOT_CREATED_ID
+        end
+
+        Vagrant::MachineState.new(state_id, short, long)
+      end
+
+      def to_s
+        id = @machine.id ? @machine.id : "new container"
+        "Docker (#{id})"
+      end
+    end
+  end
+end

--- a/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/provider.rb
+++ b/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/provider.rb
@@ -124,8 +124,12 @@ module VagrantPlugins
       # rather than directly on our system. Docker needs to run in a VM
       # when we're not on Linux, or not on a Linux that supports Docker.
       def host_vm?
-        @machine.provider_config.force_host_vm ||
-          !Vagrant::Util::Platform.linux?
+        if ENV['VAGRANT_DOCKER_REMOTE_HOST_PATCH'] == "1"
+          false
+        else
+          @machine.provider_config.force_host_vm ||
+            !Vagrant::Util::Platform.linux?
+        end
       end
 
       # Returns the SSH info for accessing the Container.
@@ -140,10 +144,17 @@ module VagrantPlugins
         # here and we let Vagrant core deal with it ;)
         return nil if !ip
 
-        {
-          host: ip,
-          port: @machine.config.ssh.guest_port
-        }
+        if ENV['VAGRANT_DOCKER_REMOTE_HOST_PATCH'] == "1"
+          {
+            host: "192.168.59.103",
+            port: "2222"
+          }
+        else
+          {
+            host: ip,
+            port: @machine.config.ssh.guest_port
+          }
+        end
       end
 
       def state

--- a/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/synced_folder.rb
+++ b/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/synced_folder.rb
@@ -1,0 +1,29 @@
+module VagrantPlugins
+  module DockerProvider
+    class SyncedFolder < Vagrant.plugin("2", :synced_folder)
+      def usable?(machine, raise_error=false)
+        # These synced folders only work if the provider is Docker
+        if machine.provider_name != :docker
+          if raise_error
+            raise Errors::SyncedFolderNonDocker,
+              provider: machine.provider_name.to_s
+          end
+
+          return false
+        end
+
+        true
+      end
+
+      def prepare(machine, folders, _opts)
+        folders.each do |id, data|
+          next if data[:ignore]
+
+          host_path  = data[:hostpath]
+          guest_path = data[:guestpath]
+          machine.provider_config.volumes << "#{host_path}:#{guest_path}"
+        end
+      end
+    end
+  end
+end

--- a/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/synced_folder.rb
+++ b/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/synced_folder.rb
@@ -21,7 +21,12 @@ module VagrantPlugins
 
           host_path  = data[:hostpath]
           guest_path = data[:guestpath]
-          machine.provider_config.volumes << "#{host_path}:#{guest_path}"
+
+          if ENV['VAGRANT_DOCKER_REMOTE_HOST_PATCH'] == "1"
+            machine.provider_config.volumes << "#{host_path.sub(/^C:\//, '/c/')}:#{guest_path}"
+          else
+            machine.provider_config.volumes << "#{host_path}:#{guest_path}"
+          end
         end
       end
     end


### PR DESCRIPTION
Now that we have the `docker.exe` running locally on Windows, together with boot2docker as the remote `$DOCKER_HOST`, it would make sense to use that as a remote docker host in Vagrant too.

Why?

 * it's possible (since the docker 1.6 windows release 3 weeks ago)
 * it's faster (no proxying via another mitchellh/boot2docker VM middleman)
 * the mitchellh/boot2docker VM is still on docker 1.2, and has not been updated since then
 * let's reuse a single docker host and not cache every image twice

As of Vagrant 1.7.2 remote docker host support does not exist yet, but should be trivial to be added:
https://twitter.com/tknerr_de/status/592555809449627648

This PR does the minimal necessary patch to the bill's kitchen vagrant 1.7.2 installation required to make remote docker host support work on windows. It is not super smart / configurable right now as it always expects the remote docker host to run on `192.168.59.103` and the container ssh port to be available on port 2222 (i.e. multi-vm scenarios probably wont work yet due to the hardcoded ssh port). 

It can be conditionally enabled or disabled via an env var:

 * `set VAGRANT_DOCKER_REMOTE_HOST_PATCH=1` enables remote docker host mode
 * `set VAGRANT_DOCKER_REMOTE_HOST_PATCH=0` or anything else disables the remote docker host mode and falls back to the standard mitchellh/boot2docker VM proxying

For convenience, it will be enabled in the `b2d-start` script and disabled again in the `b2d-stop` script.