### PR TITLE
ensure boot2docker.iso image always exists in `b2d-start`

### DIFF
--- a/files/tools/scripts/b2d-start.bat
+++ b/files/tools/scripts/b2d-start.bat
@@ -1,5 +1,11 @@
 @echo off
 
+:: check if we have the .iso file (if we don't have it, the VM won't start!)
+if not exist %HOME%\.boot2docker\boot2docker.iso (
+  echo boot2docker.iso not found in %HOME%\.boot2docker\, downloading it...
+  boot2docker download
+)
+
 :: check if "boot2docker-vm" exists already
 for /f "usebackq tokens=*" %%l in (`VBoxManage list --long vms`) do (
   if "%%l" == "Name:            boot2docker-vm" (


### PR DESCRIPTION
If it does not exist in `%HOME%\.boot2docker\`, but the "boot2docker-vm" does still exist, it will result in the VM not booting, without an error message. The underlying cause is that the VM has the iso image mounted. And if this points to a non-exisiting file, it will not come up.

This can happen after updating to a new bills kitchen release, where the boot2docker VM remains but the bills ktchen W:\home\.boot2docker dir is wiped.

This PR fixes it by ensuring the iso image always exists when running `b2d-start`

(closely related to #104)
