### PR TITLE
fix docker volume mounts, which were working with the C: drive only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 
 # 3.0-SNAPSHOT (unreleased)
 
- * ...
+ * bug fixes:
+   * fix docker volume mounts when using remote docker hosts in Vagrant (see [#107](https://github.com/tknerr/bills-kitchen/pull/107))
 
 # 3.0-rc4 (May 5, 2015)
 

--- a/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/synced_folder.rb
+++ b/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/synced_folder.rb
@@ -23,7 +23,7 @@ module VagrantPlugins
           guest_path = data[:guestpath]
 
           if ENV['VAGRANT_DOCKER_REMOTE_HOST_PATCH'] == "1"
-            machine.provider_config.volumes << "#{host_path.sub(/^C:\//, '/c/')}:#{guest_path}"
+            machine.provider_config.volumes << "#{host_path.sub(/^([A-Z]):\//) {|d| "/#{$1.downcase}/"} }:#{guest_path}"
           else
             machine.provider_config.volumes << "#{host_path}:#{guest_path}"
           end


### PR DESCRIPTION
nothing more to say... except that with this PR it works now for any drive letter