### PR TITLE
Fix Vagrant Remote Docker Host Support with Multi-machine Setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
  * bug fixes:
    * fix docker volume mounts when using remote docker hosts in Vagrant (see [#107](https://github.com/tknerr/bills-kitchen/pull/107))
    * fix build process error that occurs when `rake[recreate_dirs]` is run initially with an empty build directory (see [9ea200d](https://github.com/tknerr/bills-kitchen/commit/9ea200d75c22c405af9352e08b898fe31602ccb1), thanks @aderenbach for reporting)
+   * fix remote docker host support in multi-machine setups (see [#110](https://github.com/tknerr/bills-kitchen/pull/110))
  * improvements:
    * fix spelling errors in set-env.bat comments (see [#108](https://github.com/tknerr/bills-kitchen/pull/108), thanks @xBytez)
 
@@ -37,7 +38,7 @@
    * make the `b2d-start.bat` and `b2d-stop.bat` scripts more resilient
    * add `b2d` shortcut doskey alias for `boot2docker`
    * add `GLOBAL_VAGRANT_CACHIER_DISABLED` env var to allow for disabling vagrant-cachier in the global Vagrantfile ([#98](https://github.com/tknerr/bills-kitchen/pull/98))
-   * patch vagrant with remote docker host support; conditionally enable it `b2d-start` and disable it in `b2d-stop` (experimental, see [#100](https://github.com/tknerr/bills-kitchen/pull/100git))
+   * patch vagrant with remote docker host support; conditionally enable it `b2d-start` and disable it in `b2d-stop` (experimental, see [#100](https://github.com/tknerr/bills-kitchen/pull/100))
  * bug fixes:
    * make `bundle` and other gem binaries work in `git-bash` too [#97](https://github.com/tknerr/bills-kitchen/issues/97)
 

--- a/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/action/host_machine_port_checker.rb
+++ b/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/action/host_machine_port_checker.rb
@@ -1,0 +1,37 @@
+require "log4r"
+
+module VagrantPlugins
+  module DockerProvider
+    module Action
+      # This sets up the middleware env var to check for ports in use.
+      class HostMachinePortChecker
+        def initialize(app, env)
+          @app    = app
+          @logger = Log4r::Logger.new("vagrant::docker::hostmachineportchecker")
+        end
+
+        def call(env)
+          if ENV['VAGRANT_DOCKER_REMOTE_HOST_PATCH'] != "1"
+            return @app.call(env) if !env[:machine].provider.host_vm?
+          end
+
+          @machine = env[:machine]
+          env[:port_collision_port_check] = method(:port_check)
+
+          @app.call(env)
+        end
+
+        protected
+
+        def port_check(port)
+          if ENV['VAGRANT_DOCKER_REMOTE_HOST_PATCH'] == "1"
+            `docker ps`.lines.any? { |l| l.include? "0.0.0.0:#{port}->22/tcp" }
+          else
+            host_machine = @machine.provider.host_vm
+            host_machine.guest.capability(:port_open_check, port)
+          end
+        end
+      end
+    end
+  end
+end

--- a/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/provider.rb
+++ b/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/provider.rb
@@ -132,6 +132,18 @@ module VagrantPlugins
         end
       end
 
+      # Returns the forwarded SSH port on the host. If no port forwarding
+      # for "ssh" is found we return nil
+      def forwarded_ssh_host_port
+        @machine.config.vm.networks.each do |type, options|
+          if type == :forwarded_port && options[:id] == "ssh"
+            return options[:host]
+          end
+        end
+        # ssh portforwarding disabled?!?
+        raise "ssh port not forwarded!"
+      end
+
       # Returns the SSH info for accessing the Container.
       def ssh_info
         # If the container isn't running, we can't SSH into it
@@ -147,7 +159,7 @@ module VagrantPlugins
         if ENV['VAGRANT_DOCKER_REMOTE_HOST_PATCH'] == "1"
           {
             host: "192.168.59.103",
-            port: "2222"
+            port: forwarded_ssh_host_port
           }
         else
           {


### PR DESCRIPTION
Makes the experimental Vagrant remote docker host support from #100 work with multi-machine setups, too:

* detects and reports ssh port forwarding conflicts (port collisions) so they can be auto-corrected by Vagrant
* uses the actual forwarded ssh port instead of hardcoding port "2222"