### PR TITLE
[WIP] Improve Vagrant Remote Docker Host Support

### DIFF
--- a/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/provider.rb
+++ b/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.2/plugins/providers/docker/provider.rb
@@ -1,6 +1,7 @@
 require "digest/md5"
 require "fileutils"
 require "thread"
+require "uri"
 
 require "log4r"
 
@@ -130,6 +131,17 @@ module VagrantPlugins
           @machine.provider_config.force_host_vm ||
             !Vagrant::Util::Platform.linux?
         end
+      end
+
+      # This checks whether the host system is configured to talk to a remote
+      # docker host by inspecting the `DOCKER_HOST` env var.
+      def remote_docker_host?
+        !ENV['DOCKER_HOST'].to_s.strip.empty?
+      end
+
+      # Returns the host part from the `DOCKER_HOST` env var
+      def remote_docker_host
+        URI.parse(ENV['DOCKER_HOST']).host
       end
 
       # Returns the forwarded SSH port on the host. If no port forwarding


### PR DESCRIPTION
Continuation of the earlier work in #100 and #110 

TODO:

- [ ] detection of remote docker host via `DOCKER_HOST` env var
- [ ] config option to disable remote docker host detection (=> fallback to host_vm approach)
- [ ] ...