### PR TITLE
Update to Atom 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
  * tool updates:
    * update to ConEmu 20150513
-   * update to Atom 0.204.0
+   * update to Atom 1.0.1
    * update to Consul 0.5.2
    * update to Terraform 0.5.3
  * bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
  * tool updates:
    * update to ConEmu 20150513
-   * update to Atom 1.0.1
+   * update to Atom 1.0.0
    * update to Consul 0.5.2
    * update to Terraform 0.5.3
  * bug fixes:

--- a/Rakefile
+++ b/Rakefile
@@ -196,7 +196,6 @@ end
 def install_atom_plugins
   Bundler.with_clean_env do
     command = "#{BUILD_DIR}/set-env.bat \
-    && apm install sublime-tabs \
     && apm install atom-beautify \
     && apm install minimap \
     && apm install line-ending-converter \

--- a/Rakefile
+++ b/Rakefile
@@ -120,7 +120,7 @@ def download_tools
     %w{ get.docker.com/builds/Windows/x86_64/docker-1.6.2.exe                                                 docker/docker.exe },
     %w{ github.com/Maximus5/ConEmu/releases/download/v15.05.13/ConEmuPack.150513.7z                         conemu },
     %w{ github.com/mridgers/clink/releases/download/0.4.4/clink_0.4.4_setup.exe                             clink },
-    %w{ github.com/atom/atom/releases/download/v0.204.0/atom-windows.zip                                    atom },
+    %w{ github.com/atom/atom/releases/download/v1.0.0/atom-windows.zip                                      atom },
     %w{ github.com/msysgit/msysgit/releases/download/Git-1.9.5-preview20150319/PortableGit-1.9.5-preview20150319.7z   portablegit },
     %w{ cdn.rubyinstaller.org/archives/devkits/DevKit-mingw64-32-4.7.2-20130224-1151-sfx.exe                devkit },
     %w{ downloads.sourceforge.net/project/kdiff3/kdiff3/0.9.96/KDiff3Setup_0.9.96.exe                       kdiff3

--- a/files/home/.atom/config.cson
+++ b/files/home/.atom/config.cson
@@ -3,7 +3,7 @@
     fontFamily: "Consolas"
     showInvisibles: true
     fontSize: 17
-    lineHeight: 1.3
+    lineHeight: 1.2
   core:
     themes: [
       "atom-dark-ui"

--- a/files/home/.atom/config.cson
+++ b/files/home/.atom/config.cson
@@ -3,6 +3,7 @@
     fontFamily: "Consolas"
     showInvisibles: true
     fontSize: 17
+    lineHeight: 1.3
   core:
     themes: [
       "atom-dark-ui"

--- a/files/home/.atom/config.cson
+++ b/files/home/.atom/config.cson
@@ -15,3 +15,4 @@
     showOnStartup: false
   tabs:
     showIcons: true
+    usePreviewTabs: true

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -162,9 +162,6 @@ describe "bills kitchen" do
     end
 
     describe "atom plugins" do
-      it "has 'sublime-tabs' plugin installed" do
-        atom_plugin_installed "sublime-tabs"
-      end
       it "has 'atom-beautify' plugin installed" do
         atom_plugin_installed "atom-beautify"
       end

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -42,14 +42,14 @@ describe "bills kitchen" do
     it "installs clink 0.4.4" do
       run_cmd("#{BUILD_DIR}/tools/clink/clink.bat version").should match('Clink v0.4.4')
     end
-    it "installs atom 0.204.0" do
+    it "installs atom 1.0.0" do
       # see https://github.com/atom/atom-shell/issues/683
       # so we 1) ensure the atom.cmd is on the PATH and 2) it's the right version
       cmd_succeeds "#{BUILD_DIR}/tools/atom/Atom/resources/cli/atom.cmd -v"
-      cmd_succeeds "grep 'Package: atom@0.204.0' #{BUILD_DIR}/tools/atom/Atom/resources/LICENSE.md"
+      cmd_succeeds "grep 'Package: atom@1.0.0' #{BUILD_DIR}/tools/atom/Atom/resources/LICENSE.md"
     end
-    it "installs apm 0.168.0" do
-      run_cmd("#{BUILD_DIR}/tools/atom/Atom/resources/app/apm/bin/apm.cmd -v").should match('0.168.0')
+    it "installs apm 1.0.1" do
+      run_cmd("#{BUILD_DIR}/tools/atom/Atom/resources/app/apm/bin/apm.cmd -v").should match('1.0.1')
     end
     it "installs docker 1.6.2" do
       run_cmd("docker -v").should match('Docker version 1.6.2')


### PR DESCRIPTION
Yeah, Atom 1.0 is out :-)
http://blog.atom.io/2015/06/25/atom-1-0.html

This PR updates to atom 1.0:

 * removes sublime-tabs which is now part of atom core
 * restores line-height 1.2 and sublime-tabs behaviour
