### PR TITLE
Update to vagrant-cachier 1.2.1 with chef-zero support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
    * update to Consul 0.5.2
    * update to Terraform 0.5.3
    * update to Packer 0.8.1
+ * plugin updates:
+   * update to vagrant-cachier 1.2.1 (with chef-zero support)
  * bug fixes:
    * ensure that the vagrant remote docker host patch is always enabled (see [#114](https://github.com/tknerr/bills-kitchen/issues/114))
  * improvements:

--- a/Rakefile
+++ b/Rakefile
@@ -185,7 +185,7 @@ def install_vagrant_plugins
     command = "#{BUILD_DIR}/set-env.bat \
     && vagrant plugin install vagrant-toplevel-cookbooks --plugin-version 0.2.4 \
     && vagrant plugin install vagrant-omnibus --plugin-version 1.4.1 \
-    && vagrant plugin install vagrant-cachier --plugin-version 1.2.0 \
+    && vagrant plugin install vagrant-cachier --plugin-version 1.2.1 \
     && vagrant plugin install vagrant-proxyconf --plugin-version 1.5.0 \
     && vagrant plugin install vagrant-berkshelf --plugin-version 4.0.4 \
     && vagrant plugin install vagrant-winrm --plugin-version 0.7.0"

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -144,8 +144,8 @@ describe "bills kitchen" do
       it "has 'vagrant-omnibus (1.4.1)' plugin installed" do
         vagrant_plugin_installed "vagrant-omnibus", "1.4.1"
       end
-      it "has 'vagrant-cachier (1.2.0)' plugin installed" do
-        vagrant_plugin_installed "vagrant-cachier", "1.2.0"
+      it "has 'vagrant-cachier (1.2.1)' plugin installed" do
+        vagrant_plugin_installed "vagrant-cachier", "1.2.1"
       end
       it "has 'vagrant-proxyconf (1.5.0)' plugin installed" do
         vagrant_plugin_installed "vagrant-proxyconf", "1.5.0"


### PR DESCRIPTION
update to latest version 1.2.1 of the vagrant-cachier plugin, which supports chef-zero