### PR TITLE
Update to Docker 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
    * update to Consul 0.5.2
    * update to Terraform 0.6.1
    * update to Packer 0.8.2
+   * update to Docker 1.7.0
  * plugin updates:
    * update to vagrant-cachier 1.2.1 (with chef-zero support)
    * update to vagrant-proxyconf 1.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
    * update to Consul 0.5.2
    * update to Terraform 0.6.1
    * update to Packer 0.8.2
-   * update to Docker 1.7.0
+   * update to Docker 1.7.1
  * plugin updates:
    * update to vagrant-cachier 1.2.1 (with chef-zero support)
    * update to vagrant-proxyconf 1.5.1

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The main tools for cooking with Chef / Vagrant:
 * [Terraform](http://terraform.io/) 0.6.1
 * [Packer](http://packer.io/) 0.8.2
 * [Consul](http://consul.io/) 0.5.2
-* [Docker](http://docker.io/) 1.6.2 (using boot2docker)
+* [Docker](http://docker.io/) 1.7.0 (using boot2docker)
 
 ### Plugins
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The main tools for cooking with Chef / Vagrant:
 * [Terraform](http://terraform.io/) 0.6.1
 * [Packer](http://packer.io/) 0.8.2
 * [Consul](http://consul.io/) 0.5.2
-* [Docker](http://docker.io/) 1.7.0 (using boot2docker)
+* [Docker](http://docker.io/) 1.7.1 (using boot2docker)
 
 ### Plugins
 

--- a/Rakefile
+++ b/Rakefile
@@ -116,8 +116,8 @@ end
 
 def download_tools
   [
-    %w{ github.com/boot2docker/boot2docker-cli/releases/download/v1.7.0/boot2docker-v1.7.0-windows-amd64.exe  docker/boot2docker.exe },
-    %w{ get.docker.com/builds/Windows/x86_64/docker-1.7.0.exe                                                 docker/docker.exe },
+    %w{ github.com/boot2docker/boot2docker-cli/releases/download/v1.7.1/boot2docker-v1.7.1-windows-amd64.exe  docker/boot2docker.exe },
+    %w{ get.docker.com/builds/Windows/x86_64/docker-1.7.1.exe                                                 docker/docker.exe },
     %w{ github.com/Maximus5/ConEmu/releases/download/v15.07.28/ConEmuPack.150728.7z                         conemu },
     %w{ github.com/mridgers/clink/releases/download/0.4.4/clink_0.4.4_setup.exe                             clink },
     %w{ github.com/atom/atom/releases/download/v1.0.4/atom-windows.zip                                      atom },

--- a/Rakefile
+++ b/Rakefile
@@ -116,8 +116,8 @@ end
 
 def download_tools
   [
-    %w{ github.com/boot2docker/boot2docker-cli/releases/download/v1.6.2/boot2docker-v1.6.2-windows-amd64.exe  docker/boot2docker.exe },
-    %w{ get.docker.com/builds/Windows/x86_64/docker-1.6.2.exe                                                 docker/docker.exe },
+    %w{ github.com/boot2docker/boot2docker-cli/releases/download/v1.7.0/boot2docker-v1.7.0-windows-amd64.exe  docker/boot2docker.exe },
+    %w{ get.docker.com/builds/Windows/x86_64/docker-1.7.0.exe                                                 docker/docker.exe },
     %w{ github.com/Maximus5/ConEmu/releases/download/v15.07.28/ConEmuPack.150728.7z                         conemu },
     %w{ github.com/mridgers/clink/releases/download/0.4.4/clink_0.4.4_setup.exe                             clink },
     %w{ github.com/atom/atom/releases/download/v1.0.4/atom-windows.zip                                      atom },

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,6 @@
 version: '{build}-{branch}'
 os: Windows Server 2012 R2
 platform: x64
-environment:
-  VBOX_MSI_INSTALL_PATH: C:\VBox-4.3.12\
 init:
 install:
   - set PATH=C:\Ruby22-x64\bin;%PATH%
@@ -12,5 +10,3 @@ install:
   - bundle install
 build_script:
   - rake build
-artifacts:
-  - path: target\build\repo\vagrant-workflow-tests\acceptance.log

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,8 @@
 version: '{build}-{branch}'
 os: Windows Server 2012 R2
 platform: x64
+environment:
+  VBOX_MSI_INSTALL_PATH: C:\VBox-4.3.12\
 init:
 install:
   - set PATH=C:\Ruby22-x64\bin;%PATH%
@@ -10,3 +12,5 @@ install:
   - bundle install
 build_script:
   - rake build
+artifacts:
+  - path: target\build\repo\vagrant-workflow-tests\acceptance.log

--- a/files/tools/scripts/b2d-start.bat
+++ b/files/tools/scripts/b2d-start.bat
@@ -78,6 +78,7 @@ if "%BK_USE_PROXY%" == "1" (
 boot2docker ssh "sudo /etc/init.d/docker restart > /dev/null"
 boot2docker ssh "sudo /etc/init.d/docker status"
 
+
 ENDLOCAL
 
 
@@ -86,5 +87,12 @@ ENDLOCAL
 for /f "usebackq tokens=*" %%s in (`boot2docker ip`) do set b2d_ip=%%s
 echo updating DOCKER_HOST env var to "tcp://%b2d_ip%:2376"...
 set DOCKER_HOST=tcp://%b2d_ip%:2376
+
+:: echo the boot2docker / docker client versions
+echo boot2docker version:
+boot2docker ssh "docker -v"
+echo docker client version:
+docker -v
+
 
 :end

--- a/files/tools/scripts/b2d-start.bat
+++ b/files/tools/scripts/b2d-start.bat
@@ -76,6 +76,7 @@ if "%BK_USE_PROXY%" == "1" (
   boot2docker ssh "sudo rm -rf /var/lib/boot2docker/profile"
 )
 boot2docker ssh "sudo /etc/init.d/docker restart > /dev/null"
+boot2docker ssh "sudo /etc/init.d/docker status"
 
 
 ENDLOCAL

--- a/files/tools/scripts/b2d-start.bat
+++ b/files/tools/scripts/b2d-start.bat
@@ -54,6 +54,9 @@ set BK_ROOT_CYGPATH=%BK_ROOT_DRIVE%
 echo Adding shared folder "billskitchen" for hostpath %BK_ROOT%
 VBoxManage sharedfolder add "boot2docker-vm" --name "billskitchen" --hostpath %BK_ROOT%
 
+:: echo the config for debugging
+boot2docker config
+
 :: bring it up
 echo Bringing up the boot2docker VM...
 boot2docker up

--- a/files/tools/scripts/b2d-start.bat
+++ b/files/tools/scripts/b2d-start.bat
@@ -16,7 +16,7 @@ for /f "usebackq tokens=*" %%l in (`VBoxManage list --long vms`) do (
 
 :init
 echo No existing boot2docker-vm found in VirtualBox, initializing...
-boot2docker init
+boot2docker init --memory=512
 
 :check
 :: check if boot2docker is running
@@ -59,7 +59,7 @@ boot2docker config
 
 :: bring it up
 echo Bringing up the boot2docker VM...
-boot2docker up --memory=512 --verbose=true
+boot2docker up
 
 :: mount drive inside vbox
 echo Mounting the shared folder inside the VM to %BK_ROOT_CYGPATH%

--- a/files/tools/scripts/b2d-start.bat
+++ b/files/tools/scripts/b2d-start.bat
@@ -78,7 +78,13 @@ if "%BK_USE_PROXY%" == "1" (
 boot2docker ssh "sudo /etc/init.d/docker restart > /dev/null"
 boot2docker ssh "sudo /etc/init.d/docker status"
 
-
 ENDLOCAL
+
+
+
+:: update the DOCKER_HOST as the ip address might change
+for /f "usebackq tokens=*" %%s in (`boot2docker ip`) do set b2d_ip=%%s
+echo updating DOCKER_HOST env var to "tcp://%b2d_ip%:2376"...
+set DOCKER_HOST=tcp://%b2d_ip%:2376
 
 :end

--- a/files/tools/scripts/b2d-start.bat
+++ b/files/tools/scripts/b2d-start.bat
@@ -16,7 +16,7 @@ for /f "usebackq tokens=*" %%l in (`VBoxManage list --long vms`) do (
 
 :init
 echo No existing boot2docker-vm found in VirtualBox, initializing...
-boot2docker init --memory=512
+boot2docker init --memory=2048
 
 :check
 :: check if boot2docker is running
@@ -55,7 +55,7 @@ echo Adding shared folder "billskitchen" for hostpath %BK_ROOT%
 VBoxManage sharedfolder add "boot2docker-vm" --name "billskitchen" --hostpath %BK_ROOT%
 
 :: echo the config for debugging
-boot2docker config
+::boot2docker config
 
 :: bring it up
 echo Bringing up the boot2docker VM...

--- a/files/tools/scripts/b2d-start.bat
+++ b/files/tools/scripts/b2d-start.bat
@@ -2,8 +2,8 @@
 
 :: check if we have the .iso file (if we don't have it, the VM won't start!)
 if not exist %HOME%\.boot2docker\boot2docker.iso (
-  echo boot2docker.iso not found in %HOME%\.boot2docker\, downloading it...
-  boot2docker download
+  echo boot2docker.iso not found in %HOME%\.boot2docker\, downloading version 1.7.1...
+  curl -L -o %HOME%\.boot2docker\boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v1.7.1/boot2docker.iso
 )
 
 :: check if "boot2docker-vm" exists already

--- a/files/tools/scripts/b2d-start.bat
+++ b/files/tools/scripts/b2d-start.bat
@@ -59,7 +59,7 @@ boot2docker config
 
 :: bring it up
 echo Bringing up the boot2docker VM...
-boot2docker up
+boot2docker up --memory=512 --verbose=true
 
 :: mount drive inside vbox
 echo Mounting the shared folder inside the VM to %BK_ROOT_CYGPATH%

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -51,11 +51,11 @@ describe "bills kitchen" do
     it "installs apm 1.0.1" do
       run_cmd("#{BUILD_DIR}/tools/atom/Atom/resources/app/apm/bin/apm.cmd -v").should match('1.0.1')
     end
-    it "installs docker 1.6.2" do
-      run_cmd("docker -v").should match('Docker version 1.6.2')
+    it "installs docker 1.7.0" do
+      run_cmd("docker -v").should match('Docker version 1.7.0')
     end
-    it "installs boot2docker-cli 1.6.2" do
-      run_cmd("boot2docker version").should match('Boot2Docker-cli version: v1.6.2')
+    it "installs boot2docker-cli 1.7.0" do
+      run_cmd("boot2docker version").should match('Boot2Docker-cli version: v1.7.0')
     end
   end
 

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -51,11 +51,11 @@ describe "bills kitchen" do
     it "installs apm 1.0.1" do
       run_cmd("#{BUILD_DIR}/tools/atom/Atom/resources/app/apm/bin/apm.cmd -v").should match('1.0.1')
     end
-    it "installs docker 1.7.0" do
-      run_cmd("docker -v").should match('Docker version 1.7.0')
+    it "installs docker 1.7.1" do
+      run_cmd("docker -v").should match('Docker version 1.7.1')
     end
-    it "installs boot2docker-cli 1.7.0" do
-      run_cmd("boot2docker version").should match('Boot2Docker-cli version: v1.7.0')
+    it "installs boot2docker-cli 1.7.1" do
+      run_cmd("boot2docker version").should match('Boot2Docker-cli version: v1.7.1')
     end
   end
 


### PR DESCRIPTION
Updates both:

 * docker client to 1.7.1
 * boot2docker 1.7.1

Also replaces the `boot2docker download` command in `b2d-start.bat` with a plain `curl` command so that we have explicit control over the boot2docker iso image version that is being downloaded.

You will find some commits inbetween that optimize for running acceptance tests on appveyor (.e.g reducing memory of the boot2docker-vm), but in the end the 40 minutes we have on appveyor does not suffice for running the acceptance tests...

