### PR TITLE
[WIP] Migrate to docker-machine

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -117,6 +117,7 @@ end
 def download_tools
   [
     %w{ github.com/boot2docker/boot2docker-cli/releases/download/v1.7.1/boot2docker-v1.7.1-windows-amd64.exe  docker/boot2docker.exe },
+    %w{ github.com/docker/machine/releases/download/v0.4.0-rc2/docker-machine_windows-amd64.exe               docker/docker-machine.exe },
     %w{ get.docker.com/builds/Windows/x86_64/docker-1.7.1.exe                                                 docker/docker.exe },
     %w{ github.com/Maximus5/ConEmu/releases/download/v15.07.28/ConEmuPack.150728.7z                         conemu },
     %w{ github.com/mridgers/clink/releases/download/0.4.4/clink_0.4.4_setup.exe                             clink },
@@ -134,7 +135,10 @@ def download_tools
     %w{ opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.6.0-1.msi                  chef-dk }
   ]
   .each do |host_and_path, target_dir, includes = ''|
-    download_and_unpack "http://#{host_and_path}", "#{BUILD_DIR}/tools/#{target_dir}", includes.split('|')
+    target = "#{BUILD_DIR}/tools/#{target_dir}"
+    if !File.exist? target
+      download_and_unpack "http://#{host_and_path}", target, includes.split('|')
+    end
   end
 end
 

--- a/files/set-env.bat
+++ b/files/set-env.bat
@@ -43,6 +43,19 @@ set EDITOR=atom.sh --wait
 :: set the home dir for boot2docker
 set BOOT2DOCKER_DIR=%HOME%\.boot2docker
 
+:: set the home dir for docker-machine
+set MACHINE_STORAGE_PATH=%HOME%\.docker\machine
+
+:: set virtualbox driver options for docker-machine
+:: see https://github.com/docker/machine/blob/master/docs/drivers/virtualbox.md
+set VIRTUALBOX_MEMORY_SIZE=2048
+set VIRTUALBOX_CPU_COUNT=2
+set VIRTUALBOX_DISK_SIZE=20000
+set VIRTUALBOX_BOOT2DOCKER_URL=https://github.com/boot2docker/boot2docker/releases/download/v1.7.1/boot2docker.iso
+
+:: see https://github.com/docker/machine/issues/1573#issuecomment-127667308
+set VIRTUALBOX_HOSTONLY_CIDR=192.168.99.100/24
+
 :: init the shell for boot2docker
 set DOCKER_HOST=tcp://192.168.59.103:2376
 set DOCKER_CERT_PATH=%BOOT2DOCKER_DIR%\certs\boot2docker-vm


### PR DESCRIPTION
WIP - nothing working yet

Boot2docker is deprecated and to be replaced by docker-machine.

See here:
https://github.com/docker/machine/blob/master/docs/migrate-to-machine.md
https://github.com/docker/machine/blob/master/docs/drivers/virtualbox.md


