### PR TITLE
Update to ChefDK 0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
    * update to Terraform 0.6.1
    * update to Packer 0.8.2
    * update to Docker 1.7.1
-   * update to Vagrant 1.7.4   
+   * update to Vagrant 1.7.4
    * update to ChefDK 0.7.0
  * plugin updates:
    * update to vagrant-cachier 1.2.1 (with chef-zero support)
@@ -17,6 +17,8 @@
    * ensure that the vagrant remote docker host patch is always enabled (see [#114](https://github.com/tknerr/bills-kitchen/issues/114))
  * improvements:
    * allow to run acceptance tests using either virtualbox or docker provider
+ * patches:
+   * update the ChefDK included bundler to 1.10.6 (and [temporarily patched Vagrant](https://github.com/test-kitchen/kitchen-vagrant/issues/190#ref-commit-1176eca)) so we can benefit from the [bugfix](https://github.com/bundler/bundler/issues/3799) which makes parallel downloading work again
 
 
 # 3.0-rc5 (May 17, 2015)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
    * update to Terraform 0.6.1
    * update to Packer 0.8.2
    * update to Docker 1.7.1
-   * update to Vagrant 1.7.4
+   * update to Vagrant 1.7.4   
+   * update to ChefDK 0.7.0
  * plugin updates:
    * update to vagrant-cachier 1.2.1 (with chef-zero support)
    * update to vagrant-proxyconf 1.5.1

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The following changes are applied to your environment by running `W:\set-env.bat
 * Constraining as much as possible to the `W:\` drive:
  * `%HOME%` points to `W:\home`
  * `%VAGRANT_HOME%` points to `W:\home\.vagrant.d`
+ * `%CHEFDK_HOME%` points to `W:\home\.chefdk`
  * `%PATH%` is preprended with the bin dirs of the tools in `W:\tools\`
  * **exception**: `%VBOX_USER_HOME%` points to `%USERPROFILE%`, i.e. VirtualBox VMs are still stored under `%USERPROFILE%`
 * Fixing annoyances:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Using Bill's Kitchen itself is fairly simple. There is nothing to install, just 
 
 The main tools for cooking with Chef / Vagrant:
 
-* [ChefDK](http://www.getchef.com/downloads/chef-dk/windows/) 0.6.0, with embedded [Ruby](http://rubyinstaller.org/downloads/) 2.1.5
+* [ChefDK](http://www.getchef.com/downloads/chef-dk/windows/) 0.7.0, with embedded [Ruby](http://rubyinstaller.org/downloads/) 2.1.5
 * [DevKit](http://rubyinstaller.org/add-ons/devkit/) 4.7.2
 * [Vagrant](http://vagrantup.com/) 1.7.4
 * [Terraform](http://terraform.io/) 0.6.1

--- a/Rakefile
+++ b/Rakefile
@@ -131,7 +131,7 @@ def download_tools
     %w{ dl.bintray.com/mitchellh/terraform/terraform_0.6.1_windows_amd64.zip                                terraform },
     %w{ dl.bintray.com/mitchellh/packer/packer_0.8.2_windows_amd64.zip                                      packer },
     %w{ dl.bintray.com/mitchellh/consul/0.5.2_windows_386.zip                                               consul },
-    %w{ opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.7.0-rc.4-1.msi             chef-dk }
+    %w{ opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.7.0-1.msi                  chef-dk }
   ]
   .each do |host_and_path, target_dir, includes = ''|
     download_and_unpack "http://#{host_and_path}", "#{BUILD_DIR}/tools/#{target_dir}", includes.split('|')

--- a/Rakefile
+++ b/Rakefile
@@ -131,7 +131,7 @@ def download_tools
     %w{ dl.bintray.com/mitchellh/terraform/terraform_0.6.1_windows_amd64.zip                                terraform },
     %w{ dl.bintray.com/mitchellh/packer/packer_0.8.2_windows_amd64.zip                                      packer },
     %w{ dl.bintray.com/mitchellh/consul/0.5.2_windows_386.zip                                               consul },
-    %w{ opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.6.0-1.msi                  chef-dk }
+    %w{ opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.7.0-1.msi                  chef-dk }
   ]
   .each do |host_and_path, target_dir, includes = ''|
     download_and_unpack "http://#{host_and_path}", "#{BUILD_DIR}/tools/#{target_dir}", includes.split('|')

--- a/Rakefile
+++ b/Rakefile
@@ -131,7 +131,7 @@ def download_tools
     %w{ dl.bintray.com/mitchellh/terraform/terraform_0.6.1_windows_amd64.zip                                terraform },
     %w{ dl.bintray.com/mitchellh/packer/packer_0.8.2_windows_amd64.zip                                      packer },
     %w{ dl.bintray.com/mitchellh/consul/0.5.2_windows_386.zip                                               consul },
-    %w{ opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.7.0-1.msi                  chef-dk }
+    %w{ opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.7.0-rc.4-1.msi             chef-dk }
   ]
   .each do |host_and_path, target_dir, includes = ''|
     download_and_unpack "http://#{host_and_path}", "#{BUILD_DIR}/tools/#{target_dir}", includes.split('|')

--- a/Rakefile
+++ b/Rakefile
@@ -179,6 +179,11 @@ def fix_bundler
     && chef gem install bundler -v 1.10.6 --no-ri --no-rdoc"
     fail "updating bundler to 1.10.6 failed" unless system(command)
   end
+  # also temporarily patch vagrant until test-kitchen/kitchen-vagrant#190 is fixed
+  gemspec = "#{BUILD_DIR}/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.4/vagrant.gemspec"
+  gemspec2 = "#{BUILD_DIR}/tools/vagrant/HashiCorp/Vagrant/embedded/gems/specifications/vagrant-1.7.4.gemspec"
+  File.write(gemspec, File.read(gemspec).gsub('1.10.5', '1.10.6'))
+  File.write(gemspec2, File.read(gemspec2).gsub('1.10.5', '1.10.6'))
 end
 
 def install_knife_plugins

--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,7 @@ task :build do
   fix_chefdk
   fix_vagrant
   copy_files
+  fix_bundler
   generate_docs
   install_knife_plugins
   install_vagrant_plugins
@@ -169,6 +170,15 @@ def fix_vagrant
   orig = "#{BUILD_DIR}/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.4/plugins/synced_folders/rsync/helper.rb"
   patched = File.read(orig).gsub('hostpath = Vagrant::Util', 'hostpath = "/cygdrive" + Vagrant::Util')
   File.write(orig, patched)
+end
+
+def fix_bundler
+  # manually restore a good bundler version until chef/omnibus-chef#464 is fixed
+  Bundler.with_clean_env do
+    command = "#{BUILD_DIR}/set-env.bat \
+    && chef gem install bundler -v 1.10.6 --no-ri --no-rdoc"
+    fail "updating bundler to 1.10.6 failed" unless system(command)
+  end
 end
 
 def install_knife_plugins

--- a/files/set-env.bat
+++ b/files/set-env.bat
@@ -60,6 +60,9 @@ set GEM_PATH=%GEM_HOME%;%GEM_ROOT%
 :: that's how the PATH entries are generated for chef shell-init
 set CHEFDK_PATH_ENTRIES=%CHEFDKDIR%\bin;%CHEFDKHOMEDIR%\gem\ruby\2.1.0\bin;%CHEFDKDIR%\embedded\bin
 
+:: also set the newly introduced (as of ChefDK 0.7.0) CHEFDK_HOME environment
+set CHEFDK_HOME=%CHEFDKHOMEDIR%
+
 
 :: prompt for .gitconfig username/email
 FOR /F "usebackq tokens=*" %%a IN (`cmd /C %GITDIR%\cmd\git config --get user.name`) DO SET GIT_CONF_USERNAME=%%a

--- a/files/set-env.ps1
+++ b/files/set-env.ps1
@@ -52,6 +52,8 @@ $env:GEM_PATH = "$env:GEM_HOME;$env:GEM_ROOT"
 ## that's how the PATH entries are generated for chef shell-init
 $env:CHEFDK_PATH_ENTRIES = "$env:CHEFDKDIR\bin;$env:CHEFDKHOMEDIR\gem\ruby\2.1.0\bin;$env:CHEFDKDIR\embedded\bin"
 
+## also set the newly introduced (as of ChefDK 0.7.0) CHEFDK_HOME environment
+$env:CHEFDK_HOME=$env:CHEFDKHOMEDIR
 
 if($env:GITDIR -eq $NULL) {
 	$env:GITDIR = Join-Path $env:BK_ROOT tools\portablegit

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -111,15 +111,18 @@ describe "bills kitchen" do
         run_cmd("which gem").should match(convert_slashes("#{CHEFDK_RUBY}/bin/gem"))
       end
       it "does have it's environment properly set" do
-        # TODO: test for https://github.com/chef/chef-dk/pull/423
         chef_env = run_cmd("chef env")
-        chef_env.should match("ChefDK Home: \"#{BUILD_DIR}/home/.chefdk\"")
+        chef_env.should match("ChefDK Home: #{convert_slashes(BUILD_DIR + '/home/.chefdk')}")
+        chef_env.should match("ChefDK Install Directory: #{BUILD_DIR}/tools/chefdk")
+        chef_env.should match("Ruby Executable: #{BUILD_DIR}/tools/chefdk/embedded/bin/ruby.exe")
+        chef_env.should match("GEM ROOT: #{BUILD_DIR}/tools/chefdk/embedded/lib/ruby/gems/2.1.0")
+        chef_env.should match("GEM HOME: #{convert_slashes(BUILD_DIR + '/home/.chefdk')}/gem/ruby/2.1.0")
       end
     end
 
     describe "chefdk ruby" do
-      it "installs Chef 12.3.0" do
-        run_cmd("knife -v").should match('Chef: 12.3.0')
+      it "installs Chef 12.4.1" do
+        run_cmd("knife -v").should match('Chef: 12.4.1')
       end
       it "has RubyGems > 2.4.1 installed (fixes opscode/chef-dk#242)" do
         run_cmd("gem -v").should match('2.4.4')
@@ -134,8 +137,8 @@ describe "bills kitchen" do
       it "has ChefDK verified to work via `chef verify`" do
         cmd_succeeds "chef verify"
       end
-      it "has 'bundler (1.7.12)' gem installed" do
-        gem_installed "bundler", "1.7.12"
+      it "has 'bundler (1.10.0)' gem installed" do
+        gem_installed "bundler", "1.10.0"
       end
       it "has 'knife-audit (0.2.0)' plugin installed" do
         knife_plugin_installed "knife-audit", "0.2.0"

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -110,6 +110,11 @@ describe "bills kitchen" do
       it "provides the default `gem` command" do
         run_cmd("which gem").should match(convert_slashes("#{CHEFDK_RUBY}/bin/gem"))
       end
+      it "does have it's environment properly set" do
+        # TODO: test for https://github.com/chef/chef-dk/pull/423
+        chef_env = run_cmd("chef env")
+        chef_env.should match("ChefDK Home: \"#{BUILD_DIR}/home/.chefdk\""))
+      end
     end
 
     describe "chefdk ruby" do

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -69,6 +69,9 @@ describe "bills kitchen" do
     it "sets VAGRANT_HOME to W:/home/.vagrant.d" do
       env_match "VAGRANT_HOME=#{BUILD_DIR}/home/.vagrant.d"
     end
+    it "sets CHEFDK_HOME to W:/home/.chefdk" do
+      env_match "CHEFDK_HOME=#{BUILD_DIR}/home/.chefdk"
+    end
     it "sets VBOX_USER_HOME to %USERPROFILE%" do
       env_match "VBOX_USER_HOME=#{ENV['USERPROFILE']}"
     end

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -6,8 +6,8 @@ describe "bills kitchen" do
   include Helpers
 
   describe "tools" do
-    it "installs ChefDK 0.6.0" do
-      run_cmd("chef -v").should match('Chef Development Kit Version: 0.6.0')
+    it "installs ChefDK 0.7.0" do
+      run_cmd("chef -v").should match('Chef Development Kit Version: 0.7.0')
     end
     it "installs Vagrant 1.7.4" do
       run_cmd("vagrant -v").should match('1.7.4')

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -113,7 +113,7 @@ describe "bills kitchen" do
       it "does have it's environment properly set" do
         # TODO: test for https://github.com/chef/chef-dk/pull/423
         chef_env = run_cmd("chef env")
-        chef_env.should match("ChefDK Home: \"#{BUILD_DIR}/home/.chefdk\""))
+        chef_env.should match("ChefDK Home: \"#{BUILD_DIR}/home/.chefdk\"")
       end
     end
 

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -135,7 +135,9 @@ describe "bills kitchen" do
         Dir["#{CHEFDK_HOME}/gem/ruby/2.1.0/bin"].should be_empty
       end
       it "has ChefDK verified to work via `chef verify`" do
-        cmd_succeeds "chef verify"
+        # XXX: skip verification of chef-provisioning until chef/chef-dk#470 is fixed
+        components = %w{berkshelf test-kitchen chef-client chef-dk chefspec rubocop fauxhai knife-spork kitchen-vagrant package installation openssl}
+        cmd_succeeds "chef verify #{components.join(',')}"
       end
       it "has 'bundler (1.10.0)' gem installed" do
         gem_installed "bundler", "1.10.0"

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -132,15 +132,18 @@ describe "bills kitchen" do
       end
       it "does not have any binaries in the $HOME/.chefdk gemdir preinstalled when we ship it" do
         # because since RubyGems > 2.4.1 the ruby path in here is absolute!
-        Dir["#{CHEFDK_HOME}/gem/ruby/2.1.0/bin"].should be_empty
+        gem_binaries = Dir.glob("#{CHEFDK_HOME}/gem/ruby/2.1.0/bin/*")
+        # XXX: keep until chef/omnibus-chef#464 is shipped
+        gem_binaries.reject{|f| File.basename(f).start_with? 'bundle'}.should be_empty
       end
       it "has ChefDK verified to work via `chef verify`" do
         # XXX: skip verification of chef-provisioning until chef/chef-dk#470 is fixed
         components = %w{berkshelf test-kitchen chef-client chef-dk chefspec rubocop fauxhai knife-spork kitchen-vagrant package installation openssl}
         cmd_succeeds "chef verify #{components.join(',')}"
       end
-      it "has 'bundler (1.10.0)' gem installed" do
-        gem_installed "bundler", "1.10.0"
+      it "has 'bundler (1.10.6)' gem installed" do
+        # XXX: keep until chef/omnibus-chef#464 is shipped
+        gem_installed "bundler", "1.10.6, 1.10.0"
       end
       it "has 'knife-audit (0.2.0)' plugin installed" do
         knife_plugin_installed "knife-audit", "0.2.0"


### PR DESCRIPTION
Chef-DK 0.7.0 is about to come out:
https://github.com/chef/chef-dk/blob/0.7.0.rc.4/CHANGELOG.md#last-release-070

This PR is still work in progress. Currently it:

 * updates to 0.7.0-rc4
 * sets the new `$CHEFDK_HOME` env var
 * adds an initial test for checking `chef env`