### PR TITLE
Further Fixes in Vagrant Remote Docker Host Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
    * update to vagrant-proxyconf 1.5.1
  * bug fixes:
    * ensure that the vagrant remote docker host patch is always enabled (see [#114](https://github.com/tknerr/bills-kitchen/issues/114))
+   * get the actual remote docker host ip address from the `DOCKER_HOST` env var instead of using a hard coded default (see [#130](https://github.com/tknerr/bills-kitchen/pull/130))
+   * fix detection of the forwarded ssh port when multiple remote docker containers are started (see [#130](https://github.com/tknerr/bills-kitchen/pull/130))
  * improvements:
    * allow to run acceptance tests using either virtualbox or docker provider
  * patches:

--- a/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.4/plugins/providers/docker/provider.rb
+++ b/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.4/plugins/providers/docker/provider.rb
@@ -148,6 +148,17 @@ module VagrantPlugins
         raise "ssh port not forwarded!"
       end
 
+      # Returns the IP reported by `boot2docker ip`, falling back
+      # to 192.168.59.103 if the command execution fails.
+      def boot2docker_ip
+        @boot2docker_ip ||= begin
+            `boot2docker ip`.strip
+          rescue
+            '192.168.59.103'
+          end
+        @boot2docker_ip
+      end
+
       # Returns the SSH info for accessing the Container.
       def ssh_info
         # If the container isn't running, we can't SSH into it
@@ -162,7 +173,7 @@ module VagrantPlugins
 
         if ENV['VAGRANT_DOCKER_REMOTE_HOST_PATCH'] == "1"
           {
-            host: "192.168.59.103",
+            host: boot2docker_ip,
             port: forwarded_ssh_host_port
           }
         else

--- a/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.4/plugins/providers/docker/provider.rb
+++ b/files/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.4/plugins/providers/docker/provider.rb
@@ -150,15 +150,11 @@ module VagrantPlugins
         forwarded_ssh_ports[0]['HostPort']
       end
 
-      # Returns the IP reported by `boot2docker ip`, falling back
-      # to 192.168.59.103 if the command execution fails.
-      def boot2docker_ip
-        @boot2docker_ip ||= begin
-            `boot2docker ip`.strip
-          rescue
-            '192.168.59.103'
-          end
-        @boot2docker_ip
+      # Returns the remote docker host by parsing the `DOCKER_HOST` env var
+      def remote_docker_host
+        docker_host_uri = ENV.fetch('DOCKER_HOST', 'tcp://192.168.59.103:2376')
+        docker_host = URI.parse(docker_host_uri).host
+        docker_host
       end
 
       # Returns the SSH info for accessing the Container.
@@ -175,7 +171,7 @@ module VagrantPlugins
 
         if ENV['VAGRANT_DOCKER_REMOTE_HOST_PATCH'] == "1"
           {
-            host: boot2docker_ip,
+            host: remote_docker_host,
             port: forwarded_ssh_host_port
           }
         else


### PR DESCRIPTION
This PR fixes two issues when working with the experimental remote docker host support in Vagrant (use `set VAGRANT_DOCKER_REMOTE_HOST_PATCH=1` to enable it):

1. the remote docker host IP was hardcoded to `192.168.59.103`
2. the forwarded ssh host port was always reported as `2222` (the vagrant default for forwarding the ssh port), meaning that it was essentially broken as soon as you started a second VM

This has been fixed by:

1. parsing the remote docker host IP from the `DOCKER_HOST` env var
2. using the actual / real forwarded ssh port that `docker inspect <container>` shows