### PR TITLE
fix URLs for hashicorp downloads

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -128,10 +128,10 @@ def download_tools
         kdiff3.exe },
     %w{ the.earth.li/~sgtatham/putty/0.63/x86/putty.zip                                                     putty },
     %w{ www.itefix.net/dl/cwRsync_5.4.1_x86_Free.zip                                                        cwrsync },
-    %w{ dl.bintray.com/mitchellh/vagrant/vagrant_1.7.4.msi                                                  vagrant },
-    %w{ dl.bintray.com/mitchellh/terraform/terraform_0.6.3_windows_amd64.zip                                terraform },
-    %w{ dl.bintray.com/mitchellh/packer/packer_0.8.6_windows_amd64.zip                                      packer },
-    %w{ dl.bintray.com/mitchellh/consul/0.5.2_windows_386.zip                                               consul },
+    %w{ releases.hashicorp.com/vagrant/1.7.4/vagrant_1.7.4.msi                                              vagrant },
+    %w{ releases.hashicorp.com/terraform/0.6.3/terraform_0.6.3_windows_amd64.zip                            terraform },
+    %w{ releases.hashicorp.com/packer/0.8.6/packer_0.8.6_windows_amd64.zip                                  packer },
+    %w{ releases.hashicorp.com/consul/0.5.2/consul_0.5.2_windows_386.zip                                    consul },
     %w{ opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.7.0-1.msi                  chef-dk }
   ]
   .each do |host_and_path, target_dir, includes = ''|


### PR DESCRIPTION
The download URLs from https://dl.bintray.com no longer work anymore.

All hashicorp packages are now served from https://releases.hashicorp.com