### PR TITLE
Improve git config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 
  * improvements:
    * make sure the chef omnibus installer is cached during test-kitchen runs
-   * make sure the chef `file_cache_path` is cached during test-kitchen runs 
+   * make sure the chef `file_cache_path` is cached during test-kitchen runs
+   * add new alias `git graph` to show the commit graph / branches on the CLI
+   * adopt the new Git 2.0 push behaviour (`push.default = simple`)
 
 
 # 3.0-rc6 (Sept 7, 2015)

--- a/files/home/.gitconfig
+++ b/files/home/.gitconfig
@@ -27,6 +27,8 @@
 [http]
 	sslVerify = false
 	# proxy = http://your.proxy.org:8080
+[push]
+	default = simple
 [user]
 	name = dummy
 	email = dummy

--- a/files/home/.gitconfig
+++ b/files/home/.gitconfig
@@ -24,6 +24,7 @@
 	st = status
 	unstage = reset HEAD --
 	slog = log --pretty=oneline --abbrev-commit
+	graph = log --all --oneline --graph --decorate
 [http]
 	sslVerify = false
 	# proxy = http://your.proxy.org:8080


### PR DESCRIPTION
Improve the `.gitconfig`:

 * explicitly adopt the new Git 2.0 push behaviour (`push.default = simple`) to get rid of the warning message
 * add `git graph` alias to show the commit graph / branches on the commandline without a GUI tool