### PR TITLE
Update to Vagrant 1.8 and ChefDK 0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 # 3.0-SNAPSHOT (unreleased)
 
+ * tool updates:
+   * update to ChefDK 0.13.21
+   * update to Vagrant 1.8.1
  * improvements:
    * make sure the chef omnibus installer is cached during test-kitchen runs
    * make sure the chef `file_cache_path` is cached during test-kitchen runs

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Using Bill's Kitchen itself is fairly simple. There is nothing to install, just 
 
 The main tools for cooking with Chef / Vagrant:
 
-* [ChefDK](http://www.getchef.com/downloads/chef-dk/windows/) 0.7.0, with embedded [Ruby](http://rubyinstaller.org/downloads/) 2.1.5
+* [ChefDK](http://www.getchef.com/downloads/chef-dk/windows/) 0.13.21, with embedded [Ruby](http://rubyinstaller.org/downloads/) 2.1.8
 * [DevKit](http://rubyinstaller.org/add-ons/devkit/) 4.7.2
-* [Vagrant](http://vagrantup.com/) 1.7.4
+* [Vagrant](http://vagrantup.com/) 1.8.1
 * [Terraform](http://terraform.io/) 0.6.3
 * [Packer](http://packer.io/) 0.8.6
 * [Consul](http://consul.io/) 0.5.2

--- a/Rakefile
+++ b/Rakefile
@@ -128,7 +128,7 @@ def download_tools
         kdiff3.exe },
     %w{ the.earth.li/~sgtatham/putty/0.63/x86/putty.zip                                                     putty },
     %w{ www.itefix.net/dl/cwRsync_5.4.1_x86_Free.zip                                                        cwrsync },
-    %w{ releases.hashicorp.com/vagrant/1.7.4/vagrant_1.7.4.msi                                              vagrant },
+    %w{ releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1.msi                                              vagrant },
     %w{ releases.hashicorp.com/terraform/0.6.3/terraform_0.6.3_windows_amd64.zip                            terraform },
     %w{ releases.hashicorp.com/packer/0.8.6/packer_0.8.6_windows_amd64.zip                                  packer },
     %w{ releases.hashicorp.com/consul/0.5.2/consul_0.5.2_windows_386.zip                                    consul },

--- a/Rakefile
+++ b/Rakefile
@@ -25,7 +25,6 @@ task :build do
   download_tools
   move_chefdk
   fix_chefdk
-  fix_vagrant
   copy_files
   fix_bundler
   generate_docs
@@ -163,13 +162,6 @@ def fix_chefdk
   Dir.glob("#{BUILD_DIR}/tools/chefdk/embedded/lib/ruby/gems/2.1.0/bin/*.bat").each do |file|
     File.write(file, File.read(file).gsub('@"C:\opscode\chefdk\embedded\bin\ruby.exe" "%~dpn0" %*', '@"%~dp0\..\..\..\..\..\bin\ruby.exe" "%~dpn0" %*'))
   end
-end
-
-# workaround for mitchellh/vagrant#4073
-def fix_vagrant
-  orig = "#{BUILD_DIR}/tools/vagrant/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.7.4/plugins/synced_folders/rsync/helper.rb"
-  patched = File.read(orig).gsub('hostpath = Vagrant::Util', 'hostpath = "/cygdrive" + Vagrant::Util')
-  File.write(orig, patched)
 end
 
 def fix_bundler

--- a/Rakefile
+++ b/Rakefile
@@ -130,7 +130,7 @@ def download_tools
     %w{ releases.hashicorp.com/terraform/0.6.3/terraform_0.6.3_windows_amd64.zip                            terraform },
     %w{ releases.hashicorp.com/packer/0.8.6/packer_0.8.6_windows_amd64.zip                                  packer },
     %w{ releases.hashicorp.com/consul/0.5.2/consul_0.5.2_windows_386.zip                                    consul },
-    %w{ opscode-omnibus-packages.s3.amazonaws.com/windows/2008r2/x86_64/chefdk-0.7.0-1.msi                  chef-dk }
+    %w{ packages.chef.io/stable/windows/2008r2/chefdk-0.13.21-1-x86.msi                                     cdk }
   ]
   .each do |host_and_path, target_dir, includes = ''|
     download_and_unpack "http://#{host_and_path}", "#{BUILD_DIR}/tools/#{target_dir}", includes.split('|')
@@ -139,8 +139,10 @@ end
 
 # move chef-dk to a shorter path to reduce the likeliness that a gem fails to install due to max path length
 def move_chefdk
-  FileUtils.mv "#{BUILD_DIR}/tools/chef-dk/opscode/chefdk", "#{BUILD_DIR}/tools/chefdk"
-  FileUtils.rm_rf "#{BUILD_DIR}/tools/chef-dk"
+  FileUtils.mv "#{BUILD_DIR}/tools/cdk/opscode/chefdk", "#{BUILD_DIR}/tools/chefdk"
+  # chefdk requires a two step install
+  unpack "#{BUILD_DIR}/tools/cdk/opscode/chefdk.zip", "#{BUILD_DIR}/tools/chefdk"
+  FileUtils.rm_rf "#{BUILD_DIR}/tools/cdk"
 end
 
 # ensure omnibus / chef-dk use the embedded ruby, see opscode/chef#1512

--- a/Rakefile
+++ b/Rakefile
@@ -148,12 +148,12 @@ end
 # ensure omnibus / chef-dk use the embedded ruby, see opscode/chef#1512
 def fix_chefdk
   Dir.glob("#{BUILD_DIR}/tools/chefdk/bin/*").each do |file|
-    if File.extname(file).empty?  # do this only for the extensionless files
+    if File.extname(file).empty? && File.exist?("#{file}.bat")  # do this only for the extensionless .bat counterparts
       File.write(file, File.read(file).gsub('#!C:/opscode/chefdk/embedded/bin/ruby.exe', '#!/usr/bin/env ruby'))
     end
   end
   Dir.glob("#{BUILD_DIR}/tools/chefdk/embedded/bin/*").each do |file|
-    if File.extname(file).empty?  # do this only for the extensionless files
+    if File.extname(file).empty? && File.exist?("#{file}.bat")  # do this only for the extensionless .bat counterparts
       File.write(file, File.read(file).gsub('#!C:/opscode/chefdk/embedded/bin/ruby.exe', '#!/usr/bin/env ruby'))
     end
   end

--- a/Rakefile
+++ b/Rakefile
@@ -324,7 +324,7 @@ end
 
 def pack(target_dir, archive)
   puts "packing '#{target_dir}' into '#{archive}'"
-  system("cd #{target_dir} && \"#{ZIP_EXE}\" a -t7z -y \"#{archive}\" \".\" 1> NUL && cd ..")
+  system("pushd #{target_dir} && \"#{ZIP_EXE}\" a -t7z -y \"#{archive}\" \".\" 1> NUL && popd")
 end
 
 def release?

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -6,8 +6,8 @@ describe "bills kitchen" do
   include Helpers
 
   describe "tools" do
-    it "installs ChefDK 0.7.0" do
-      run_cmd("chef -v").should match('Chef Development Kit Version: 0.7.0')
+    it "installs ChefDK 0.13.21" do
+      run_cmd("chef -v").should match('Chef Development Kit Version: 0.13.21')
     end
     it "installs Vagrant 1.8.1" do
       run_cmd("vagrant -v").should match('1.8.1')
@@ -121,11 +121,14 @@ describe "bills kitchen" do
     end
 
     describe "chefdk ruby" do
-      it "installs Chef 12.4.1" do
-        run_cmd("knife -v").should match('Chef: 12.4.1')
+      it "installs Chef 12.9.41" do
+        run_cmd("knife -v").should match('Chef: 12.9.41')
       end
       it "has RubyGems > 2.4.1 installed (fixes opscode/chef-dk#242)" do
-        run_cmd("gem -v").should match('2.4.4')
+        run_cmd("gem -v").should match('2.6.3')
+      end
+      it "has bundler >= 1.10.6 installed (fixes chef/omnibus-chef#464)" do
+        gem_installed "bundler", "1.11.2"
       end
       it "uses $HOME/.chefdk as the gemdir" do
         run_cmd("#{CHEFDK_RUBY}/bin/gem environment gemdir").should match("#{CHEFDK_HOME}/gem/ruby/2.1.0")
@@ -133,17 +136,11 @@ describe "bills kitchen" do
       it "does not have any binaries in the $HOME/.chefdk gemdir preinstalled when we ship it" do
         # because since RubyGems > 2.4.1 the ruby path in here is absolute!
         gem_binaries = Dir.glob("#{CHEFDK_HOME}/gem/ruby/2.1.0/bin/*")
-        # XXX: keep until chef/omnibus-chef#464 is shipped
-        gem_binaries.reject{|f| File.basename(f).start_with? 'bundle'}.should be_empty
       end
       it "has ChefDK verified to work via `chef verify`" do
         # XXX: skip verification of chef-provisioning until chef/chef-dk#470 is fixed
-        components = %w{berkshelf test-kitchen chef-client chef-dk chefspec rubocop fauxhai knife-spork kitchen-vagrant package installation openssl}
-        cmd_succeeds "chef verify #{components.join(',')}"
-      end
-      it "has 'bundler (1.10.6)' gem installed" do
-        # XXX: keep until chef/omnibus-chef#464 is shipped
-        gem_installed "bundler", "1.10.6, 1.10.0"
+        components = %w{berkshelf tk-policyfile-provisioner test-kitchen chef-client chef-dk chefspec generated-cookbooks-pass-chefspec rubocop fauxhai knife-spork kitchen-vagrant package\ installation openssl inspec}
+        cmd_succeeds "chef verify #{components.join(' ')}"
       end
       it "has 'knife-audit (0.2.0)' plugin installed" do
         knife_plugin_installed "knife-audit", "0.2.0"

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -9,8 +9,8 @@ describe "bills kitchen" do
     it "installs ChefDK 0.7.0" do
       run_cmd("chef -v").should match('Chef Development Kit Version: 0.7.0')
     end
-    it "installs Vagrant 1.7.4" do
-      run_cmd("vagrant -v").should match('1.7.4')
+    it "installs Vagrant 1.8.1" do
+      run_cmd("vagrant -v").should match('1.8.1')
     end
     it "installs Terraform 0.6.3" do
       run_cmd("terraform --version").should match('0.6.3')


### PR DESCRIPTION
This PR updates:

 * vagrant 1.8.1
 * chefdk  0.13.21

Along the way it removes some workarounds that are not necessary anymore