### PR TITLE
Differentiate between :clean vs :wipe tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
    * update to Terraform 0.6.16
    * update to Packer 0.10.1
    * update to Consul 0.6.4
+   * update to ConEmu 2016031
  * improvements:
    * make sure the chef omnibus installer is cached during test-kitchen runs
    * make sure the chef `file_cache_path` is cached during test-kitchen runs

--- a/Rakefile
+++ b/Rakefile
@@ -117,7 +117,7 @@ def download_tools
   [
     %w{ github.com/boot2docker/boot2docker-cli/releases/download/v1.7.1/boot2docker-v1.7.1-windows-amd64.exe  docker/boot2docker.exe },
     %w{ get.docker.com/builds/Windows/x86_64/docker-1.7.1.exe                                                 docker/docker.exe },
-    %w{ github.com/Maximus5/ConEmu/releases/download/v15.07.28/ConEmuPack.150728.7z                         conemu },
+    %w{ github.com/Maximus5/ConEmu/releases/download/v16.03.01/ConEmuPack.160301.7z                         conemu },
     %w{ github.com/mridgers/clink/releases/download/0.4.4/clink_0.4.4_setup.exe                             clink },
     %w{ github.com/atom/atom/releases/download/v1.0.9/atom-windows.zip                                      atom },
     %w{ github.com/git-for-windows/git/releases/download/v2.5.0.windows.1/PortableGit-2.5.0-64-bit.7z.exe   portablegit },

--- a/Rakefile
+++ b/Rakefile
@@ -14,9 +14,16 @@ CACHE_DIR   = "#{BASE_DIR}/target/cache"
 ZIP_EXE = 'C:\Program Files\7-Zip\7z.exe'
 
 
-desc 'cleans all output and cache directories'
+desc 'cleans the build output directory'
 task :clean do
-  FileUtils.rm_r TARGET_DIR, secure: true
+  purge_atom_plugins_with_insanely_long_path
+  FileUtils.rm_rf BUILD_DIR, secure: true
+end
+
+desc 'wipes all output and cache directories'
+task :wipe do
+  purge_atom_plugins_with_insanely_long_path
+  FileUtils.rm_rf TARGET_DIR, secure: true
 end
 
 desc 'downloads required resources and builds the devpack binary'

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ task :wipe do
 end
 
 desc 'downloads required resources and builds the devpack binary'
-task :build do
+task :build => :clean do
   recreate_dirs
   download_tools
   move_chefdk
@@ -91,8 +91,6 @@ def acceptance_test_run_cmd(provider)
 end
 
 def recreate_dirs
-  purge_atom_plugins_with_insanely_long_path
-  FileUtils.rm_rf BUILD_DIR, secure: true
   %w{ home repo tools }.each do |dir|
     FileUtils.mkdir_p "#{BUILD_DIR}/#{dir}"
   end


### PR DESCRIPTION
This PR adds a differentiaton of the `:clean` vs `:wipe` tasks:

 * `rake clean` only cleans the build output directory
 * `rake wipe` cleans the whole target directory, including the cache for downloaded files

Also, the method for removing the atom packages with overly long windows paths has been improved to use the windows builtin robocopy tool, instead of trying to uninstall the plugins. So it works more reliably now. 