### PR TITLE
Update to latest Atom 1.7.3 Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
    * update to Consul 0.6.4
    * update to ConEmu 2016031
    * update to Git for Windows 2.8.2
+   * update to Atom Editor 1.7.3
  * improvements:
    * make sure the chef omnibus installer is cached during test-kitchen runs
    * make sure the chef `file_cache_path` is cached during test-kitchen runs

--- a/Rakefile
+++ b/Rakefile
@@ -127,7 +127,7 @@ def download_tools
     %w{ get.docker.com/builds/Windows/x86_64/docker-1.7.1.exe                                                 docker/docker.exe },
     %w{ github.com/Maximus5/ConEmu/releases/download/v16.03.01/ConEmuPack.160301.7z                         conemu },
     %w{ github.com/mridgers/clink/releases/download/0.4.4/clink_0.4.4_setup.exe                             clink },
-    %w{ github.com/atom/atom/releases/download/v1.0.9/atom-windows.zip                                      atom },
+    %w{ github.com/atom/atom/releases/download/v1.7.3/atom-windows.zip                                      atom },
     %w{ github.com/git-for-windows/git/releases/download/v2.8.2.windows.1/PortableGit-2.8.2-64-bit.7z.exe   portablegit },
     %w{ cdn.rubyinstaller.org/archives/devkits/DevKit-mingw64-32-4.7.2-20130224-1151-sfx.exe                devkit },
     %w{ downloads.sourceforge.net/project/kdiff3/kdiff3/0.9.96/KDiff3Setup_0.9.96.exe                       kdiff3

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -42,14 +42,14 @@ describe "bills kitchen" do
     it "installs clink 0.4.4" do
       run_cmd("#{BUILD_DIR}/tools/clink/clink.bat version").should match('Clink v0.4.4')
     end
-    it "installs atom 1.0.9" do
+    it "installs atom 1.7.3" do
       # see https://github.com/atom/atom-shell/issues/683
       # so we 1) ensure the atom.cmd is on the PATH and 2) it's the right version
       cmd_succeeds "#{BUILD_DIR}/tools/atom/Atom/resources/cli/atom.cmd -v"
-      cmd_succeeds "grep 'Package: atom@1.0.9' #{BUILD_DIR}/tools/atom/Atom/resources/LICENSE.md"
+      cmd_succeeds "grep 'Package: atom@1.7.3' #{BUILD_DIR}/tools/atom/Atom/resources/LICENSE.md"
     end
-    it "installs apm 1.0.4" do
-      run_cmd("#{BUILD_DIR}/tools/atom/Atom/resources/app/apm/bin/apm.cmd -v").should match('1.0.4')
+    it "installs apm 1.9.2" do
+      run_cmd("#{BUILD_DIR}/tools/atom/Atom/resources/app/apm/bin/apm.cmd -v").should match('1.9.2')
     end
     it "installs docker 1.7.1" do
       run_cmd("docker -v").should match('Docker version 1.7.1')


### PR DESCRIPTION
Updates to Atom 1.7.3

Seems to work well after a while, only the `~` char can not by typed. Might be related to https://github.com/f/atom-term2/issues/127, but googling around did not reveal a workaround so far. Will merge anyway and fix this later

