### PR TITLE
Update Vagrant Plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
    * update to ConEmu 2016031
    * update to Git for Windows 2.8.2
    * update to Atom Editor 1.7.3
+ * plugin updates:
+   * update to vagrant-proxyconf 1.5.2
+   * update to vagrant-berkshelf 4.1.0
  * improvements:
    * make sure the chef omnibus installer is cached during test-kitchen runs
    * make sure the chef `file_cache_path` is cached during test-kitchen runs

--- a/Rakefile
+++ b/Rakefile
@@ -188,8 +188,8 @@ def install_vagrant_plugins
     && vagrant plugin install vagrant-toplevel-cookbooks --plugin-version 0.2.4 \
     && vagrant plugin install vagrant-omnibus --plugin-version 1.4.1 \
     && vagrant plugin install vagrant-cachier --plugin-version 1.2.1 \
-    && vagrant plugin install vagrant-proxyconf --plugin-version 1.5.1 \
-    && vagrant plugin install vagrant-berkshelf --plugin-version 4.0.4 \
+    && vagrant plugin install vagrant-proxyconf --plugin-version 1.5.2 \
+    && vagrant plugin install vagrant-berkshelf --plugin-version 4.1.0 \
     && vagrant plugin install vagrant-winrm --plugin-version 0.7.0"
     fail "vagrant plugin installation failed" unless system(command)
   end

--- a/spec/integration/bills_kitchen_spec.rb
+++ b/spec/integration/bills_kitchen_spec.rb
@@ -160,11 +160,11 @@ describe "bills kitchen" do
       it "has 'vagrant-cachier (1.2.1)' plugin installed" do
         vagrant_plugin_installed "vagrant-cachier", "1.2.1"
       end
-      it "has 'vagrant-proxyconf (1.5.1)' plugin installed" do
-        vagrant_plugin_installed "vagrant-proxyconf", "1.5.1"
+      it "has 'vagrant-proxyconf (1.5.2)' plugin installed" do
+        vagrant_plugin_installed "vagrant-proxyconf", "1.5.2"
       end
-      it "has 'vagrant-berkshelf (4.0.4)' plugin installed" do
-        vagrant_plugin_installed "vagrant-berkshelf", "4.0.4"
+      it "has 'vagrant-berkshelf (4.1.0)' plugin installed" do
+        vagrant_plugin_installed "vagrant-berkshelf", "4.1.0"
       end
       it "has 'vagrant-winrm (0.7.0)' plugin installed" do
         vagrant_plugin_installed "vagrant-winrm", "0.7.0"


### PR DESCRIPTION
Updates: 

 * vagrant-proxyconf to 1.5.2 
 * vagrant-berkshelf to 4.1.0

All other vagrant plugins are up to date